### PR TITLE
fix: 로그인페이지 Next로 마이그레이션

### DIFF
--- a/src/components/pages/login/index.tsx
+++ b/src/components/pages/login/index.tsx
@@ -5,10 +5,10 @@ import { WORD_LIST_PATH } from '@/routes/path.ts';
 import LogoSvg from '@/components/svg-component/LogoSvg';
 import { useRouter } from 'next/navigation';
 
-export default function Login_Client() {
+export default function Login() {
   const router = useRouter();
 
-  const onClickNonMember = () => {
+  const handleClickNonMember = () => {
     router.push(WORD_LIST_PATH);
   };
 
@@ -32,14 +32,14 @@ export default function Login_Client() {
           </div>
           <span
             className="text-center text-[#442E2E]"
-            onClick={onClickNonMember}
+            onClick={handleClickNonMember}
           >
             카카오톡으로 시작하기
           </span>
         </button>
         <button
           className="w-full text-base font-semibold text-main-black opacity-60 p-3.5"
-          onClick={onClickNonMember}
+          onClick={handleClickNonMember}
         >
           비로그인으로 이용하기
         </button>


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
- [x] 헤더 컴포넌트 구현 
-->

로그인페이지는 마이그레이션할 게 없어서 함수 이름만 수정했습니다.

## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->

- 페이지 함수 이름에서 client 제거 (`Login_Client` -> `Login`)
- 이벤트핸들러 함수 이름 변경 (`onClickNonMember` -> `handleClickNonMember`)

## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->

근데 `npm run dev`하면
![image](https://github.com/Devminjeong-eum/frontend/assets/55550034/669ac98e-312b-49df-bb93-08e2988f8def)
사진과 같은 메시지와 함께 `tsconfig.json`파일에 `"allowJs": true`자동으로 추가돼서 없애줘야 하던데, 원래 이런걸까요..?