### PR TITLE
feat: React-Query Provider 세팅 및 Detail 페이지 Prefetch

### DIFF
--- a/src/app/words/[word-id]/page.tsx
+++ b/src/app/words/[word-id]/page.tsx
@@ -1,5 +1,0 @@
-import Word_Client from "@/components/pages/detail";
-
-export default function WordsPage() {
-  return <Word_Client />;
-}

--- a/src/app/words/[wordId]/loading.tsx
+++ b/src/app/words/[wordId]/loading.tsx
@@ -1,0 +1,5 @@
+import DetailLoading from '@/components/pages/detail/DetailLoading.tsx';
+
+export default function loading() {
+  return <DetailLoading />;
+}

--- a/src/app/words/[wordId]/page.tsx
+++ b/src/app/words/[wordId]/page.tsx
@@ -1,0 +1,32 @@
+import WordDetailClientPage from '@/components/pages/detail';
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from '@tanstack/react-query';
+import { fetchFakeWordDetail } from '@/hooks/query/useWordDetail.ts';
+import { notFound } from 'next/navigation';
+
+export default async function WordsPage({
+  params,
+}: {
+  params: { wordId: string };
+}) {
+  const queryClient = new QueryClient();
+  const wordId = Number(params.wordId);
+
+  if (isNaN(wordId)) {
+    notFound();
+  }
+
+  await queryClient.prefetchQuery({
+    queryFn: () => fetchFakeWordDetail(wordId),
+    queryKey: ['get_wordDetail', wordId],
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <WordDetailClientPage wordId={wordId} />
+    </HydrationBoundary>
+  );
+}

--- a/src/components/common/BackButton.tsx
+++ b/src/components/common/BackButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import BackButtonSvg from '@/components/svg-component/BackButtonSvg';
 
 import { useRouter } from 'next/navigation';

--- a/src/components/pages/detail/index.tsx
+++ b/src/components/pages/detail/index.tsx
@@ -3,20 +3,24 @@
 import CorrectSvg from '@/components/svg-component/CorrectSvg.tsx';
 import WrongSvg from '@/components/svg-component/WrongSvg.tsx';
 
-// import useWordDetail from '@/hooks/query/useWordDetail.ts';
+import useWordDetail from '@/hooks/query/useWordDetail.ts';
 import DetailHeader from './DetailHeader.tsx';
 
-export default function Word_Client() {
-  // const {
-  //   data: {
-  //     wordName,
-  //     wordDescription,
-  //     wordSpeak,
-  //     wrongSpeak,
-  //     wordExample,
-  //     wordDiacritic,
-  //   },
-  // } = useWordDetail(Number(1));
+type Props = {
+  wordId: number;
+};
+
+export default function WordDetailClientPage({ wordId }: Props) {
+  const {
+    data: {
+      wordName,
+      wordDescription,
+      wordSpeak,
+      wrongSpeak,
+      wordExample,
+      wordDiacritic,
+    },
+  } = useWordDetail(wordId);
 
   return (
     <div>
@@ -27,9 +31,9 @@ export default function Word_Client() {
         <div className="pt-6 pb-[22px]">
           <div className="flex items-end mb-[8px] gap-2.5">
             <h1 className="text-[30px] align-bottom font-semibold text-white">
-              {''}
+              {wordName}
             </h1>
-            <span className="text-white font-medium pb-[6px]">{'wordSpeak'}</span>
+            <span className="text-white font-medium pb-[6px]">{wordSpeak}</span>
           </div>
           <div className="flex flex-col gap-2.5">
             <div className="h-[25px] bg-[#4068D0] rounded-[8px] flex items-center gap-2.5 pl-2">
@@ -38,7 +42,7 @@ export default function Word_Client() {
                 올바른 발음
               </span>
               <span className="text-[13px] text-[#EAEEF8]">
-                {'wordSpeak'} {'wordDiacritic'}
+                {wordSpeak} {wordDiacritic}
               </span>
             </div>
             <div className="h-[25px] bg-[#6264A8] rounded-[8px] flex items-center gap-2.5 pl-2">
@@ -46,7 +50,7 @@ export default function Word_Client() {
               <span className="text-[13px] font-semibold text-white">
                 잘못된 발음
               </span>
-              <span className="text-[13px] text-[#EBEBF5]">{'wrongSpeak'}</span>
+              <span className="text-[13px] text-[#EBEBF5]">{wrongSpeak}</span>
             </div>
           </div>
         </div>
@@ -54,12 +58,12 @@ export default function Word_Client() {
       <main className="p-5 flex flex-col gap-2">
         <div className="p-[18px] rounded-[16px] border border-[#F2F4F9] shadow-base bg-white">
           <h3 className="font-semibold text-main-black pb-1.5">의미</h3>
-          <p className="text-main-gray">{'wordDescription'}</p>
+          <p className="text-main-gray">{wordDescription}</p>
         </div>
-        {true && (
+        {wordExample && (
           <div className="p-[18px] rounded-[16px] border border-[#F2F4F9] shadow-base bg-white">
             <h3 className="font-semibold text-main-black pb-1.5">예문</h3>
-            {'wordExample'
+            {wordExample
               .split('$')
               .filter((example) => example.trim())
               .map((example, idx) => (

--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -24,7 +24,7 @@ export default function Home_Client() {
             wordDiacritic={index.toString()}
             wordDescription={index.toString()}
             key={index.toString()}
-            wordId={index}
+            [wordId]={index}
             wordName={index.toString()}
             wordSpeak={index.toString()}
           />

--- a/src/components/pages/search/index.tsx
+++ b/src/components/pages/search/index.tsx
@@ -39,7 +39,7 @@ export default function Search_Client() {
   return (
     <div className="p-5 rounded-[24px] bg-[#FBFCFE] -mt-[20px] z-50 flex flex-col gap-[12px]">
       {/* {searchWord?.data?.wordAll.map((item: SearchWord) => (
-        <SearchItem key={item.wordId} item={item} />
+        <SearchItem key={item.[wordId]} item={item} />
       ))} */}
       {['1', '2', '3', '4'].map((item) => (
         <SearchItem key={item} item={item} />

--- a/src/hooks/query/useWordDetail.ts
+++ b/src/hooks/query/useWordDetail.ts
@@ -1,10 +1,29 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { WordDetail } from '@/types/main.ts';
-import { fetchWordDetail } from '@/api/main.ts';
+// import { fetchWordDetail } from '@/api/main.ts';
+
+export const fetchFakeWordDetail = (wordId: number): Promise<WordDetail> =>
+  new Promise((resolve) => {
+    setTimeout(
+      () =>
+        resolve({
+          wordId,
+          wordName: 'AJAX',
+          wordDiacritic: '[ey-jaks]',
+          wordDescription:
+            '개발용어의 정의가 들어가는 부분입니다. 개발용어의 정의가 들어가는 부분입니다. 개발용어의 정의가 들어가는 부분입니다. 개발용어의 정의임.',
+          wordSpeak: '에이잭스',
+          wrongSpeak: '아작스, 아약스, 에이작스, 에작스',
+          wordExample:
+            '개발용어의 정의가 들어가는 부분입니다.조금 길 수도 있어요 이렇게요.$개발용어의 정의가 들어가는 부분입니다.$개발용어의 정의가 들어가는 부분입니다.$개발용어의 정의가 들어가는 부분입니다. ',
+        }),
+      3000,
+    );
+  });
 
 const useWordDetail = (wordId: number) => {
   return useSuspenseQuery<WordDetail>({
-    queryFn: () => fetchWordDetail(wordId),
+    queryFn: () => fetchFakeWordDetail(wordId),
     queryKey: ['get_wordDetail', wordId],
   });
 };
@@ -14,7 +33,7 @@ export default useWordDetail;
 /*
 NOTE: 예시 데이터
 {
-          wordId : 1,
+          [wordId] : 1,
           wordName: 'AJAX',
           wordDiacritic: '[ey-jaks]',
           wordDescription:

--- a/src/providers/QueryProvider.tsx
+++ b/src/providers/QueryProvider.tsx
@@ -1,11 +1,33 @@
 'use client';
-
-import React, { PropsWithChildren, useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PropsWithChildren } from 'react';
 
-function QueryProvider({ children }: PropsWithChildren) {
-  const [client] = useState(new QueryClient());
-  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000,
+      },
+    },
+  });
 }
 
-export default QueryProvider;
+let browserQueryClient: QueryClient | undefined = undefined;
+
+function getQueryClient() {
+  if (typeof window === 'undefined') {
+    // Server: always make a new query client
+    return makeQueryClient();
+  } else {
+    if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    return browserQueryClient;
+  }
+}
+
+export default function QueryProvider({ children }: PropsWithChildren) {
+  const queryClient = getQueryClient();
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
- [x] 헤더 컴포넌트 구현 
-->
- [x] react-query SSR 세팅
- [x] Detail Page prefetch
- [x] word-id to wordId  변경


## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->
<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->
react-query의 prefetch를 사용해서 클라이언트에서 useQuery사용해도 data fetching이 안일어나도록 세팅했습니다. 

다이나믹 라우트 시 word-id 시 변수 명으로 추출이 불가능하기 때문에, 폴더 명을 wordId로 변경했습니다!

## 📌 구현 결과
<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->
시연 완료!

## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->

개인적으로 제가 맡은 부분인 Detail 페이지 같은 경우는 react query를 사용하는 것 보다 fetch만 쓰는게 개인적으로 더 좋은 방식이라고 생각합니다,, 
데이터를 한 번만 불러오면 되기 때문에 useQuery를 사용해서 디테일 페이지 전체를 클라이언트 컴포넌트로 만드는 것이 비효율적이라고 생각 하기 때문입니다. 
따라서 추후에는 useQuery를 제거 할 예정입니다!
혹시 이와 관련해서 이야기하고 싶은 부분이나, 고려해야 할 사항들이 있을까요? 