### PR TITLE
feat: 카카오 로그인 api 연동

### DIFF
--- a/src/app/api/auth/kakao/redirect/route.ts
+++ b/src/app/api/auth/kakao/redirect/route.ts
@@ -1,0 +1,27 @@
+import { login } from '@/fetcher';
+import { NextResponse } from 'next/server';
+// import { cookies } from 'next/headers';
+
+export async function GET(request: Request) {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+
+  const { searchParams } = new URL(request.url);
+  const code = searchParams.get('code');
+
+  if (!code) {
+    console.error('인증에 필요한 code parameter가 query에 없습니다.');
+    return NextResponse.redirect(`${baseUrl}/api/auth/kakao`);
+  }
+
+  try {
+    const response = await login(code);
+    if (response) {
+      return NextResponse.redirect(`${baseUrl}/home`);
+      //const cookie = cookies();
+      //console.log('쿠키', cookie.getAll());
+    }
+  } catch (err) {
+    console.error(err);
+    return NextResponse.redirect(`${baseUrl}`);
+  }
+}

--- a/src/app/api/auth/kakao/redirect/route.ts
+++ b/src/app/api/auth/kakao/redirect/route.ts
@@ -9,7 +9,8 @@ export async function GET(request: Request) {
   const code = searchParams.get('code');
 
   if (!code) {
-    console.error('인증에 필요한 code parameter가 query에 없습니다.');
+    // FIXME
+    console.log('인증에 필요한 code parameter가 query에 없습니다.');
     return NextResponse.redirect(`${baseUrl}/api/auth/kakao`);
   }
 
@@ -21,7 +22,8 @@ export async function GET(request: Request) {
       //console.log('쿠키', cookie.getAll());
     }
   } catch (err) {
-    console.error(err);
+    // FIXME
+    console.log(err);
     return NextResponse.redirect(`${baseUrl}`);
   }
 }

--- a/src/app/api/auth/kakao/route.ts
+++ b/src/app/api/auth/kakao/route.ts
@@ -1,3 +1,4 @@
+import { redirect } from 'next/navigation';
 import { NextResponse } from 'next/server';
 
 const KAKAO_OAUTH_URL = 'https://kauth.kakao.com/oauth/authorize';
@@ -22,5 +23,5 @@ export async function GET() {
     kakaoOauthRedirectUri || DEV_KAKAO_REDIRECT_URL,
   );
 
-  return NextResponse.redirect(kakaoOauthUrl.toString());
+  return redirect(kakaoOauthUrl.toString());
 }

--- a/src/app/api/auth/kakao/route.ts
+++ b/src/app/api/auth/kakao/route.ts
@@ -1,4 +1,3 @@
-// import { redirect } from 'next/navigation';
 import { NextResponse } from 'next/server';
 
 const KAKAO_OAUTH_URL = 'https://kauth.kakao.com/oauth/authorize';

--- a/src/app/api/auth/kakao/route.ts
+++ b/src/app/api/auth/kakao/route.ts
@@ -1,0 +1,27 @@
+// import { redirect } from 'next/navigation';
+import { NextResponse } from 'next/server';
+
+const KAKAO_OAUTH_URL = 'https://kauth.kakao.com/oauth/authorize';
+const DEV_KAKAO_REDIRECT_URL = `${process.env.NEXT_PUBLIC_BASE_URL}/api/auth/kakao/redirect`;
+
+export async function GET() {
+  const kakaoRestApiKey = process.env.KAKAO_CLIENT_ID;
+  const kakaoOauthRedirectUri = process.env.KAKAO_REDIRECT_URI;
+
+  if (!kakaoRestApiKey) {
+    return NextResponse.json(null, {
+      status: 500,
+      statusText: 'Kakao Rest Api key 가 없습니다.',
+    });
+  }
+
+  const kakaoOauthUrl = new URL(KAKAO_OAUTH_URL);
+  kakaoOauthUrl.searchParams.set('client_id', kakaoRestApiKey);
+  kakaoOauthUrl.searchParams.set('response_type', 'code');
+  kakaoOauthUrl.searchParams.set(
+    'redirect_uri',
+    kakaoOauthRedirectUri || DEV_KAKAO_REDIRECT_URL,
+  );
+
+  return NextResponse.redirect(kakaoOauthUrl.toString());
+}

--- a/src/components/pages/login/index.tsx
+++ b/src/components/pages/login/index.tsx
@@ -1,17 +1,9 @@
-'use client';
-
 import KakaotalkSvg from '@/components/svg-component/KakaotalkSvg';
 import { WORD_LIST_PATH } from '@/routes/path.ts';
 import LogoSvg from '@/components/svg-component/LogoSvg';
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 
 export default function Login() {
-  const router = useRouter();
-
-  const handleClickNonMember = () => {
-    router.push(WORD_LIST_PATH);
-  };
-
   return (
     <div className="flex flex-col items-center justify-between mt-[30vh] h-[70vh] px-5">
       <div className="flex flex-col items-center">
@@ -26,23 +18,26 @@ export default function Login() {
         </span>
       </div>
       <div className="w-full flex flex-col gap-2 pb-7">
-        <button className="relative flex items-center justify-center bg-[#FFE34E] text-base font-semibold rounded-2xl p-3.5 w-full">
-          <div className="absolute left-6">
-            <KakaotalkSvg />
-          </div>
-          <span
-            className="text-center text-[#442E2E]"
-            onClick={handleClickNonMember}
+        <Link href="/api/auth/kakao">
+          <button
+            className="relative flex items-center justify-center bg-[#FFE34E] text-base font-semibold rounded-2xl p-3.5 w-full"
           >
-            카카오톡으로 시작하기
-          </span>
-        </button>
-        <button
-          className="w-full text-base font-semibold text-main-black opacity-60 p-3.5"
-          onClick={handleClickNonMember}
-        >
-          비로그인으로 이용하기
-        </button>
+            <div className="absolute left-6">
+              <KakaotalkSvg />
+            </div>
+            <span className="text-center text-[#442E2E]">
+              카카오톡으로 시작하기
+            </span>
+          </button>
+        </Link>
+        <Link href={WORD_LIST_PATH}>
+          <button
+            className="w-full text-base font-semibold text-main-black opacity-60 p-3.5"
+            // onClick={handleClickNonMember}
+          >
+            비로그인으로 이용하기
+          </button>
+        </Link>
       </div>
     </div>
   );

--- a/src/components/pages/login/index.tsx
+++ b/src/components/pages/login/index.tsx
@@ -19,9 +19,7 @@ export default function Login() {
       </div>
       <div className="w-full flex flex-col gap-2 pb-7">
         <Link href="/api/auth/kakao">
-          <button
-            className="relative flex items-center justify-center bg-[#FFE34E] text-base font-semibold rounded-2xl p-3.5 w-full"
-          >
+          <button className="relative flex items-center justify-center bg-[#FFE34E] text-base font-semibold rounded-2xl p-3.5 w-full">
             <div className="absolute left-6">
               <KakaotalkSvg />
             </div>
@@ -31,10 +29,7 @@ export default function Login() {
           </button>
         </Link>
         <Link href={WORD_LIST_PATH}>
-          <button
-            className="w-full text-base font-semibold text-main-black opacity-60 p-3.5"
-            // onClick={handleClickNonMember}
-          >
+          <button className="w-full text-base font-semibold text-main-black opacity-60 p-3.5">
             비로그인으로 이용하기
           </button>
         </Link>

--- a/src/fetcher/index.ts
+++ b/src/fetcher/index.ts
@@ -11,3 +11,14 @@ export const getWordDetail = async (wordId: string) => {
     notFound();
   }
 };
+
+export const login = async (code: string) => {
+  try {
+    return await backendFetch(`/auth/kakao`, {
+      params: { code },
+    });
+  } catch (e) {
+    console.error('login error: ', e);
+    throw e;
+  }
+};


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
- [x] 카카오 로그인 api 연동

## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->
루키의 의견대로 라우트 핸들러를 이용하여 카카오 로그인을 수행하도록 구현했습니다.

1. 카카오톡으로 로그인하기 버튼을 클릭하면 `/api/auth/kakao`로 이동합니다.
2. `/api/auth/kakao`의 route.ts파일에서 `env`파일의 `CLIENT_ID`, `REDIRECT_URI`를 이용하여 카카오톡 로그인 페이지로 `redirect` 요청합니다.
3. 카카오톡 로그인 페이지가 뜨고 로그인에 성공하면 `/api/auth/kakao/redirect`로 `redirect`됩니다.
4. `/api/auth/kakao/redirect`의 route.ts파일에서 `code`를 파싱하여 백엔드에 login api를 요청합니다.
5. 4번에서 성공하면 `/home`으로 이동합니다.

## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->
- 팀 노션에 .env페이지의 프론트엔드 .env를 추가해주셔야 합니다.
- 로그인에 성공하면 쿠키가 세팅되는지 루키에게 아직 물어보지 못했습니다.
- 생각해보니 로그아웃 기능도 필요할까요?
- 현재 로그인에 성공 후 `/home`로 이동한 상태에서 뒤로 가기를 클릭했을 때, 카카오 로그인 페이지가 뜹니다. 카카오 로그인 페이지가 아니라 `/`으로 이동하도록 해서 로그인이 되었다면 `/home`으로 이동하도록 구현하고 싶었는데 잘 되지 않았습니다... 그래서 아래 코드처럼 시도했었는데 그래도 카카오 로그인 페이지로 이동하더라구요😭 `/`으로 이동하도록 구현할 수 있는 방법 없을까요?

### 시도했던 방법,,
로그인에 성공하면 `/`에 `?userId=${response.data.id}`를 담아서 redirect ->`/`에서 `sessionStorage`에 `userId`를 저장하고 `/`으로 이동 -> `sessionStorage`에 `userId`가 있기 때문에 `/home`으로 이동

Login컴포넌트에 추가했던 부분
```next.js
'use client';

import KakaotalkSvg from '@/components/svg-component/KakaotalkSvg';
import { WORD_LIST_PATH } from '@/routes/path.ts';
import LogoSvg from '@/components/svg-component/LogoSvg';
import Link from 'next/link';
import { useRouter, useSearchParams } from 'next/navigation';
import { useEffect } from 'react';

export default function Login() {
  const router = useRouter();
  const searchParams = useSearchParams();

  useEffect(() => {
    const storedUserId = sessionStorage.getItem('userId');
    const userId = searchParams.get('userId');
    console.log('userId', userId);

    if (userId) {
      sessionStorage.setItem('userId', userId);
      router.replace(LOGIN_PATH);
    } else if (storedUserId) {
      router.push(WORD_LIST_PATH);
    }
  }, [router, searchParams]);
  ...
```

`/api/auth/kakao/redirect/route.ts`의 `return`부분 수정
```next.js
return NextResponse.redirect(
        `http://localhost:3000/?userId=${response.data.id}`);
```