### PR TITLE
hotfix: 로그인 페이지, 디테일 페이지 에러 수정

### DIFF
--- a/src/app/words/[wordId]/page.tsx
+++ b/src/app/words/[wordId]/page.tsx
@@ -17,7 +17,7 @@ export default async function WordsPage({
       description,
       diacritic,
       pronunciation,
-      wrongPronunciations,
+      wrongPronunciation,
       exampleSentence,
     },
   } = await getWordDetail(wordId);
@@ -71,7 +71,7 @@ export default async function WordsPage({
                 <span className="text-[13px] font-semibold text-white">
                   잘못된 발음
                 </span>
-                {wrongPronunciations.map((wrongPronunciation, idx) => (
+                {wrongPronunciation.map((wrongPronunciation, idx) => (
                   <span className="text-[13px] text-[#EBEBF5]" key={idx}>
                     {wrongPronunciation}
                   </span>

--- a/src/components/pages/login/index.tsx
+++ b/src/components/pages/login/index.tsx
@@ -1,10 +1,11 @@
+'use client';
+
 import KakaotalkSvg from '@/components/svg-component/KakaotalkSvg';
 import { WORD_LIST_PATH } from '@/routes/path.ts';
 import LogoSvg from '@/components/svg-component/LogoSvg';
 import Link from 'next/link';
 
 export default function Login() {
-
   const handleKakaoLogin = () => {
     window.location.href = '/api/auth/kakao';
   };
@@ -23,7 +24,10 @@ export default function Login() {
         </span>
       </div>
       <div className="w-full flex flex-col gap-2 pb-7">
-        <button className="relative flex items-center justify-center bg-[#FFE34E] text-base font-semibold rounded-2xl p-3.5 w-full" onClick={handleKakaoLogin}>
+        <button
+          className="relative flex items-center justify-center bg-[#FFE34E] text-base font-semibold rounded-2xl p-3.5 w-full"
+          onClick={handleKakaoLogin}
+        >
           <div className="absolute left-6">
             <KakaotalkSvg />
           </div>

--- a/src/fetcher/types.ts
+++ b/src/fetcher/types.ts
@@ -4,7 +4,7 @@ export type WordDetail = {
   description: string;
   diacritic: string[];
   pronunciation: string[];
-  wrongPronunciations: string[];
+  wrongPronunciation: string[];
   // NOTE: \n으로 구분해 사용
   exampleSentence: string;
 


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
- [x] 헤더 컴포넌트 구현 
-->
- Login 컴포넌트 클라이언트 컴포넌트로 변경
- 디테일 페이지 응답 데이터 wrongPronunciations -> wrongPronunciation 수정

## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->

## 📌 구현 결과
<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->