### PR TITLE
[DEV-76] hotfix: 메타데이터 빌드 에러나는 부분 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,9 +6,11 @@ import { GoogleAnalytics } from '@next/third-parties/google';
 import Script from 'next/script';
 import { Metadata } from 'next';
 
+const PRODUCTION_URL = 'https://dev-malssami.site';
+
 const baseUrl =
   process.env.NODE_ENV === 'production'
-    ? process.env.PRODUCTION_URL
+    ? PRODUCTION_URL
     : process.env.NEXT_PUBLIC_BASE_URL;
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -28,11 +30,11 @@ export const metadata: Metadata = {
     index: true,
     follow: true,
   },
-  metadataBase: new URL(baseUrl || 'https://dev-malssami.site'),
+  metadataBase: new URL(baseUrl || PRODUCTION_URL),
   openGraph: {
     title: {
       template: '데브말싸미 | %s',
-      default: '데브마싸미 | 개발 용어 발음 사전',
+      default: '데브말싸미 | 개발 용어 발음 사전',
     },
     description:
       '발음이 헷갈리는 개발 용어에 대해 손쉽게 발음과 뜻을 검색해보세요.',

--- a/src/app/user/wordbook/page.tsx
+++ b/src/app/user/wordbook/page.tsx
@@ -27,6 +27,10 @@ export async function generateMetadata(
     ...parentMetadata,
     title: '단어장',
     description: '좋아요한 단어를 확인하고 관리해보세요.',
+    robots: {
+      index: false,
+      follow: false,
+    },
     openGraph: {
       ...openGraph,
       title: '단어장',

--- a/src/app/user/wordbook/page.tsx
+++ b/src/app/user/wordbook/page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import Wordbook from '@/components/pages/wordbook';
 import QUERY_KEYS from '@/constants/queryKey';
 import {
@@ -13,7 +14,10 @@ import {
 import { ResolvingMetadata } from 'next';
 
 // eslint-disable-next-line react-refresh/only-export-components
-export async function generateMetadata(parent: ResolvingMetadata) {
+export async function generateMetadata(
+  _: { [x: string]: never },
+  parent: ResolvingMetadata,
+) {
   const parentMetadata = (await parent) || [];
 
   const openGraph = parentMetadata?.openGraph ?? {};

--- a/src/app/word/search/page.tsx
+++ b/src/app/word/search/page.tsx
@@ -1,9 +1,11 @@
 import { ResolvingMetadata } from 'next';
 import PageClient from './PageClient';
-
+//searchParams: { [key: string]: string | string[] | undefined }
 // eslint-disable-next-line react-refresh/only-export-components
 export async function generateMetadata(
-  { searchParams }: { searchParams: { keyword: string } },
+  {
+    searchParams,
+  }: { searchParams: { [key: string]: string | string[] | undefined } },
   parent: ResolvingMetadata,
 ) {
   const parentMetadata = (await parent) || [];


### PR DESCRIPTION
## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->

- 빌드에러가 나는 부분 타입 지정해주었습니다!
- 프로덕션 URL을 상수로 이용하도록 수정 
- 오타 수정
- 단어장 페이지는 어차피 로그인한 유저만 접근할 수 있기 때문에 `robots=noindex, nofollow`로 지정하는 게 맞는 것 같아서 지정했습니다!
