### PR TITLE
[DEV-80] hotfix: 빌드 에러 수정

### DIFF
--- a/src/app/user/wordbook/page.tsx
+++ b/src/app/user/wordbook/page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import Wordbook from '@/components/pages/wordbook';
 import QUERY_KEYS from '@/constants/queryKey';
 import {

--- a/src/app/word/search/page.tsx
+++ b/src/app/word/search/page.tsx
@@ -1,6 +1,6 @@
 import { ResolvingMetadata } from 'next';
 import PageClient from './PageClient';
-//searchParams: { [key: string]: string | string[] | undefined }
+
 // eslint-disable-next-line react-refresh/only-export-components
 export async function generateMetadata(
   {
@@ -27,7 +27,7 @@ export async function generateMetadata(
       ...openGraph,
       title: { absoulte: `'${searchParams.keyword}'의 검색결과 | 데브말싸미` },
       description: `'${searchParams.keyword}'에 대한 검색 결과를 확인해보세요.`,
-      url: 'https://dev-malssami.site/quiz',
+      url: 'https://dev-malssami.site/search',
     },
     twitter: {
       ...twitter,

--- a/src/components/pages/wordbook/index.tsx
+++ b/src/components/pages/wordbook/index.tsx
@@ -65,13 +65,11 @@ export default function Wordbook() {
                     name={item.name}
                     pronunciation={item.pronunciation}
                     isLike={true}
-
                     currentPage={1}
-                    handleModal={() => {}}
-                    likeCount={0}
                     handleModal={() => {
-                      // NOTE: handleModal 필요
+                      //NOTE: handleModal 필요
                     }}
+                    likeCount={0}
                   />
                 ))}
             </div>


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
- [x] 헤더 컴포넌트 구현 
-->


## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->

- 사용하지 않는 린트룰 주석 때문에 린트 오류가 발생해서 제거해주었습니다.
- wordbook에서 WordItem컴포넌트를 사용할 때 handleModal이 중복으로 선언되어있어서 린트 오류가 발생하길래 중복 제거해주었습니다.

lint랑 bulid 둘다 확인했습니다..!이젠 정말 될거에요..!

## 📌 구현 결과
<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->