### PR TITLE
[DEV-67]: Detail Page UI 수정 반영

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -10,9 +10,8 @@ export const addLike = async (wordId: string) => {
       method: 'PATCH',
     });
   } catch (e) {
-    if (e instanceof Error) {
-      console.log(e.message);
-    }
+    console.log('error: ', JSON.parse(e.message).statusCode);
+
     // NOTE: 발생할 수 있는 에러
     // 401 => 권한 없음 => 로그인 모달
     // 500 => 서버 에러
@@ -27,9 +26,8 @@ export const subLike = async (wordId: string) => {
       method: 'DELETE',
     });
   } catch (e) {
-    if (e instanceof Error) {
-      console.log(e.message);
-    }
+    console.log('error: ', JSON.parse(e.message).statusCode);
+
     // NOTE: 발생할 수 있는 에러
     // 401 => 권한 없음 => 로그인 모달
     // 500 => 서버 에러

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -10,7 +10,7 @@ export const addLike = async (wordId: string) => {
       method: 'PATCH',
     });
   } catch (e) {
-    console.log('error: ', JSON.parse(e.message).statusCode);
+    console.log(e);
 
     // NOTE: 발생할 수 있는 에러
     // 401 => 권한 없음 => 로그인 모달
@@ -26,7 +26,7 @@ export const subLike = async (wordId: string) => {
       method: 'DELETE',
     });
   } catch (e) {
-    console.log('error: ', JSON.parse(e.message).statusCode);
+    console.log(e);
 
     // NOTE: 발생할 수 있는 에러
     // 401 => 권한 없음 => 로그인 모달

--- a/src/app/words/[wordName]/page.tsx
+++ b/src/app/words/[wordName]/page.tsx
@@ -1,13 +1,12 @@
 import DetailHeader from '@/components/pages/detail/DetailHeader.tsx';
 import LikeButton from '@/components/pages/detail/LikeButton.tsx';
-import CorrectSvg from '@/components/svg-component/CorrectSvg.tsx';
-import WrongSvg from '@/components/svg-component/WrongSvg.tsx';
 import ReportButton from '@/components/pages/detail/ReportButton.tsx';
 
 import type { DefaultRes, FetchRes, WordDetail } from '@/fetcher/types.ts';
 import { serverFetch } from '@/fetcher/serverFetch.ts';
 import { notFound } from 'next/navigation';
 import { ResolvingMetadata } from 'next';
+import PronunciationDetail from '@/components/pages/detail/PronunciationDetail.tsx';
 
 // eslint-disable-next-line react-refresh/only-export-components
 export async function generateMetadata(
@@ -92,17 +91,15 @@ export default async function WordsPage({
   만약 다를 시 구글 스프레드 시트에서 변경해야 함
   */
 
-  const correctWordLen = Math.min(pronunciation.length, diacritic.length);
-
   return (
     <>
-      <div className="bg-main-gradient-full px-[16px]">
+      <div className="bg-main-gradient-full px-[22px]">
         <header className="w-full">
           <DetailHeader />
         </header>
-        <div className="pt-6 pb-[22px]">
-          <div className="flex justify-between">
-            <div className="flex items-end mb-[8px] gap-2.5">
+        <div className="pt-[18px]">
+          <div className="flex items-start justify-between">
+            <div className="flex flex-col mb-[8px]">
               <h1 className="text-[30px] align-bottom font-semibold text-white">
                 {name}
               </h1>
@@ -117,38 +114,11 @@ export default async function WordsPage({
               wordId={id}
             />
           </div>
-          <div className="inline-flex flex-col gap-2.5">
-            <div className="flex flex-shrink">
-              <div className="h-[25px] bg-[#4068D0] rounded-[8px] flex items-center gap-2.5 px-2">
-                <CorrectSvg />
-                <span className="text-[13px] font-semibold text-white">
-                  올바른 발음
-                </span>
-                <>
-                  <div className="text-[13px] text-[#EAEEF8]">
-                    {new Array(correctWordLen).fill(0).map((_, idx) => (
-                      <span key={idx}>
-                        {pronunciation[idx]} {diacritic[idx]}
-                      </span>
-                    ))}
-                  </div>
-                </>
-              </div>
-            </div>
-            <div className="flex flex-shrink">
-              <div className="h-[25px] bg-[#6264A8] rounded-[8px] flex items-center gap-2.5 px-2">
-                <WrongSvg />
-                <span className="text-[13px] font-semibold text-white">
-                  잘못된 발음
-                </span>
-                {wrongPronunciation.map((wrongPronunciation, idx) => (
-                  <span className="text-[13px] text-[#EBEBF5]" key={idx}>
-                    {wrongPronunciation}
-                  </span>
-                ))}
-              </div>
-            </div>
-          </div>
+          <PronunciationDetail
+            pronunciation={pronunciation}
+            diacritic={diacritic}
+            wrongPronunciation={wrongPronunciation}
+          />
         </div>
       </div>
       <main className="p-5 flex flex-col gap-2">

--- a/src/app/words/[wordName]/page.tsx
+++ b/src/app/words/[wordName]/page.tsx
@@ -34,13 +34,13 @@ export async function generateMetadata(
     },
     openGraph: {
       ...openGraph,
-      title: { absoulte: `'${name}' | 데브말싸미` },
+      title: { absolute: `'${name}' | 데브말싸미` },
       description: `올바른 발음: ${pronunciation} 잘못된 발음: ${wrongPronunciation}`,
       url: `https://dev-malssami.site/words/${name}`,
     },
     twitter: {
       ...twitter,
-      title: { absoulte: `'${name}' | 데브말싸미` },
+      title: { absolute: `'${name}' | 데브말싸미` },
       description: `올바른 발음: ${pronunciation} 잘못된 발음: ${wrongPronunciation}`,
     },
   };

--- a/src/components/common/LoginAlertModal.tsx
+++ b/src/components/common/LoginAlertModal.tsx
@@ -2,6 +2,7 @@ import LockSmallSvg from '@/components/svg-component/LockSmallSvg';
 import clsx from 'clsx';
 import Link from 'next/link';
 import { createPortal } from 'react-dom';
+import { LOGIN_PATH } from '@/routes/path.ts';
 
 type Props = {
   isOpen: boolean;
@@ -25,7 +26,7 @@ export default function LoginAlertModal({ isOpen }: Props) {
         <p>로그인이 필요한 서비스에요.</p>
       </div>
       <Link
-        href={'/'}
+        href={LOGIN_PATH}
         className="font-semibold hover:underline underline-offset-[3px] pr-[18px]"
       >
         로그인하기

--- a/src/components/pages/detail/DetailHeader.tsx
+++ b/src/components/pages/detail/DetailHeader.tsx
@@ -7,7 +7,7 @@ export default function DetailHeader() {
   return (
     <div className="h-12 flex justify-between items-center border-b border-[#4152C1]">
       <BackButton />
-      <h1 className="text-white">개발용어</h1>
+      <h1 className="text-white">개발 용어</h1>
       <URLShareButton />
     </div>
   );

--- a/src/components/pages/detail/LikeButton.tsx
+++ b/src/components/pages/detail/LikeButton.tsx
@@ -3,6 +3,7 @@
 import DetailLikeSvg from '@/components/svg-component/DetailLikeSvg.tsx';
 import DetailLikeActiveSvg from '@/components/svg-component/DetailLikeActiveSvg.tsx';
 import { useOptimisticLike } from '@/hooks/useOptimisticLike.ts';
+import LoginAlertModal from '@/components/common/LoginAlertModal.tsx';
 
 interface Props {
   wordId: string;
@@ -23,20 +24,24 @@ export default function LikeButton({
     });
 
   // TODO: loading 시 클릭 안되게 할 필요 있음
+
   return (
-    <div className="flex flex-col justify-center items-center cursor-pointer">
-      <button
-        onClick={optimisticLikeState.isLike ? handleSubLike : handleAddLike}
-      >
-        {optimisticLikeState.isLike ? (
-          <DetailLikeActiveSvg />
-        ) : (
-          <DetailLikeSvg />
-        )}
-      </button>
-      <span className="text-xs text-[#E1E2F8]">
-        {optimisticLikeState.likeCount}
-      </span>
-    </div>
+    <>
+      <div className="flex flex-col justify-center items-center cursor-pointer">
+        <button
+          onClick={optimisticLikeState.isLike ? handleSubLike : handleAddLike}
+        >
+          {optimisticLikeState.isLike ? (
+            <DetailLikeActiveSvg />
+          ) : (
+            <DetailLikeSvg />
+          )}
+        </button>
+        <span className="text-xs text-[#E1E2F8]">
+          {optimisticLikeState.likeCount}
+        </span>
+      </div>
+      <LoginAlertModal isOpen={true} />
+    </>
   );
 }

--- a/src/components/pages/detail/LikeButton.tsx
+++ b/src/components/pages/detail/LikeButton.tsx
@@ -3,7 +3,6 @@
 import DetailLikeSvg from '@/components/svg-component/DetailLikeSvg.tsx';
 import DetailLikeActiveSvg from '@/components/svg-component/DetailLikeActiveSvg.tsx';
 import { useOptimisticLike } from '@/hooks/useOptimisticLike.ts';
-import LoginAlertModal from '@/components/common/LoginAlertModal.tsx';
 
 interface Props {
   wordId: string;
@@ -41,7 +40,7 @@ export default function LikeButton({
           {optimisticLikeState.likeCount}
         </span>
       </div>
-      <LoginAlertModal isOpen={true} />
+      {/*<LoginAlertModal isOpen={true} />*/}
     </>
   );
 }

--- a/src/components/pages/detail/PronunciationDetail.tsx
+++ b/src/components/pages/detail/PronunciationDetail.tsx
@@ -35,7 +35,8 @@ const PronunciationDetail = ({
           <div className="text-[15px]">
             {new Array(correctWordLen).fill(0).map((_, idx) => (
               <span key={idx}>
-                {pronunciation[idx]} {diacritic[idx]},
+                {pronunciation[idx]} {diacritic[idx]}
+                {idx !== correctWordLen - 1 ? ' , ' : ''}
               </span>
             ))}
           </div>
@@ -46,10 +47,10 @@ const PronunciationDetail = ({
             잘못된 발음
           </span>
           <div className="text-[15px]">
-            {wrongPronunciation.map((wrongPronunciation, idx) => (
+            {wrongPronunciation.map((wrong, idx) => (
               <span key={idx}>
-                {wrongPronunciation}
-                {idx + 1 !== wrongPronunciation.length ? ', ' : ''}
+                {wrong}
+                {idx !== wrongPronunciation.length - 1 ? ' , ' : ''}
               </span>
             ))}
           </div>

--- a/src/components/pages/detail/PronunciationDetail.tsx
+++ b/src/components/pages/detail/PronunciationDetail.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import React, { useState } from 'react';
+import DetailPronunciationCorrectSvg from '@/components/svg-component/DetailPronunciationCorrectSvg.tsx';
+import DetailPronunciationWrongSvg from '@/components/svg-component/DetailPronunciationWrongSvg.tsx';
+import DetailPronunciationShowArrowSvg from '@/components/svg-component/DetailPronunciationShowArrowSvg.tsx';
+import DetailPronunciationCloseArrowSvg from '@/components/svg-component/DetailPronunciationCloseArrowSvg.tsx';
+import clsx from 'clsx';
+
+interface Props {
+  pronunciation: string[];
+  diacritic: string[];
+  wrongPronunciation: string[];
+}
+
+const PronunciationDetail = ({
+  pronunciation,
+  diacritic,
+  wrongPronunciation,
+}: Props) => {
+  const [isShowDetail, setIsShowDetail] = useState(true);
+
+  const correctWordLen = Math.min(pronunciation.length, diacritic.length);
+
+  return (
+    <div className="relative pb-4">
+      <div
+        className={`flex flex-col gap-2 transition-all overflow-hidden ${clsx(isShowDetail ? 'max-h-[100vh]' : 'max-h-[0px]')}`}
+      >
+        <div className="px-3.5 rounded-[14px] bg-[#D9E6FF] pt-3.5 pb-3">
+          <span className="flex gap-1 items-center font-semibold text-main-blue text-sm">
+            <DetailPronunciationCorrectSvg />
+            올바른 발음
+          </span>
+          <div className="text-[15px]">
+            {new Array(correctWordLen).fill(0).map((_, idx) => (
+              <span key={idx}>
+                {pronunciation[idx]} {diacritic[idx]},
+              </span>
+            ))}
+          </div>
+        </div>
+        <div className="px-3.5 rounded-[14px] bg-[#FFE5F5] pt-3.5 pb-3">
+          <span className="flex gap-1 items-center font-semibold text-[#912828] text-sm">
+            <DetailPronunciationWrongSvg />
+            잘못된 발음
+          </span>
+          <div className="text-[15px]">
+            {wrongPronunciation.map((wrongPronunciation, idx) => (
+              <span key={idx}>
+                {wrongPronunciation}
+                {idx + 1 !== wrongPronunciation.length ? ', ' : ''}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div
+        className="bottom-0 absolute left-[-22px] w-[calc(100%+44px)] h-[58px] bg-[#575ADA] flex items-center px-[22px] text-white justify-between cursor-pointer"
+        onClick={() => setIsShowDetail((prev) => !prev)}
+      >
+        용어발음 자세히 보기
+        {isShowDetail ? (
+          <DetailPronunciationCloseArrowSvg />
+        ) : (
+          <DetailPronunciationShowArrowSvg />
+        )}
+      </div>
+      <div className="h-[58px]" />
+    </div>
+  );
+};
+
+export default PronunciationDetail;

--- a/src/components/pages/detail/PronunciationDetail.tsx
+++ b/src/components/pages/detail/PronunciationDetail.tsx
@@ -1,11 +1,11 @@
 'use client';
 
+import clsx from 'clsx';
 import React, { useState } from 'react';
 import DetailPronunciationCorrectSvg from '@/components/svg-component/DetailPronunciationCorrectSvg.tsx';
 import DetailPronunciationWrongSvg from '@/components/svg-component/DetailPronunciationWrongSvg.tsx';
 import DetailPronunciationShowArrowSvg from '@/components/svg-component/DetailPronunciationShowArrowSvg.tsx';
 import DetailPronunciationCloseArrowSvg from '@/components/svg-component/DetailPronunciationCloseArrowSvg.tsx';
-import clsx from 'clsx';
 
 interface Props {
   pronunciation: string[];

--- a/src/components/svg-component/DetailPronunciationCloseArrowSvg.tsx
+++ b/src/components/svg-component/DetailPronunciationCloseArrowSvg.tsx
@@ -1,0 +1,19 @@
+export default function DetailPronunciationCloseArrowSvg() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M5 16L12 9L19 16"
+        stroke="#BBC6EB"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/components/svg-component/DetailPronunciationCorrectSvg.tsx
+++ b/src/components/svg-component/DetailPronunciationCorrectSvg.tsx
@@ -1,0 +1,13 @@
+export default function DetailPronunciationCorrectSvg() {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 13 13"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="6.5" cy="6.5" r="4.75" stroke="#0C3FC1" strokeWidth="1.5" />
+    </svg>
+  );
+}

--- a/src/components/svg-component/DetailPronunciationShowArrowSvg.tsx
+++ b/src/components/svg-component/DetailPronunciationShowArrowSvg.tsx
@@ -1,0 +1,19 @@
+export default function DetailPronunciationShowArrowSvg() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M5 9L12 16L19 9"
+        stroke="#BBC6EB"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/components/svg-component/DetailPronunciationWrongSvg.tsx
+++ b/src/components/svg-component/DetailPronunciationWrongSvg.tsx
@@ -1,0 +1,24 @@
+export default function DetailPronunciationWrongSvg() {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 13 13"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M11.0779 2.07053L2.92203 10.9295"
+        stroke="#912828"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M2.92212 2.07053L11.078 10.9295"
+        stroke="#912828"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/src/hooks/mutation/useAddLike.ts
+++ b/src/hooks/mutation/useAddLike.ts
@@ -1,9 +1,9 @@
 import { useMutation } from '@tanstack/react-query';
 import { updateLike } from '@/fetcher';
 
-const useAddLike = (wordId: string) => {
+const useAddLike = () => {
   return useMutation({
-    mutationFn: () => updateLike(wordId),
+    mutationFn: (wordId: string) => updateLike(wordId),
   });
 };
 

--- a/src/hooks/mutation/useDeleteLike.ts
+++ b/src/hooks/mutation/useDeleteLike.ts
@@ -1,9 +1,9 @@
 import { useMutation } from '@tanstack/react-query';
 import { deleteLike } from '@/fetcher';
 
-const useDeleteLike = (wordId: string) => {
+const useDeleteLike = () => {
   return useMutation({
-    mutationFn: () => deleteLike(wordId),
+    mutationFn: (wordId: string) => deleteLike(wordId),
   });
 };
 

--- a/src/hooks/useOptimisticLike.ts
+++ b/src/hooks/useOptimisticLike.ts
@@ -1,4 +1,4 @@
-import { useOptimistic } from 'react';
+import { useOptimistic, useState } from 'react';
 
 import { addLike, subLike } from '@/actions';
 
@@ -10,7 +10,7 @@ interface Props {
 export const useOptimisticLike = ({ wordId, isLike, likeCount }: Props) => {
   // const addLikeMutation = useAddLike(wordId);
   // const deleteLikeMutation = useDeleteLike(wordId);
-
+  const [isLogin, setIsLogin] = useState(false);
   const [optimisticLikeState, setOptimisticLike] = useOptimistic<
     {
       isLike: boolean;
@@ -46,5 +46,6 @@ export const useOptimisticLike = ({ wordId, isLike, likeCount }: Props) => {
     setOptimisticLike,
     handleAddLike,
     handleSubLike,
+    isLogin,
   };
 };

--- a/src/hooks/useOptimisticLike.ts
+++ b/src/hooks/useOptimisticLike.ts
@@ -1,4 +1,4 @@
-import { useOptimistic, useState } from 'react';
+import { useOptimistic } from 'react';
 
 import { addLike, subLike } from '@/actions';
 
@@ -10,7 +10,6 @@ interface Props {
 export const useOptimisticLike = ({ wordId, isLike, likeCount }: Props) => {
   // const addLikeMutation = useAddLike(wordId);
   // const deleteLikeMutation = useDeleteLike(wordId);
-  const [isLogin, setIsLogin] = useState(false);
   const [optimisticLikeState, setOptimisticLike] = useOptimistic<
     {
       isLike: boolean;
@@ -46,6 +45,5 @@ export const useOptimisticLike = ({ wordId, isLike, likeCount }: Props) => {
     setOptimisticLike,
     handleAddLike,
     handleSubLike,
-    isLogin,
   };
 };


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
- [x] 헤더 컴포넌트 구현 
-->
- [x] 디테일 페이지 디자인 반영
- 
## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->
여러개의 발음을 커버하기 위해서 디테일 페이지에서 디자인 수정이 되었고, 해당 부분을 반영하였습니다. 
접고 펼칠 때 transition으로 자연스럽게 만들었습니다. 

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->

## 📌 구현 결과
<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

디자인
![image](https://github.com/Devminjeong-eum/frontend/assets/75849590/6fa02a3c-e5e2-4651-85fd-f9573608efcc)

구현
![image](https://github.com/Devminjeong-eum/frontend/assets/75849590/2a6b667e-cdc0-47e5-818c-2c6f4495dd3c)

## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->