### PR TITLE
[DEV-64] fix: 메인 페이지 좋아요시 리렌더링 이슈 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1213,12 +1213,13 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2553,10 +2554,11 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -3201,6 +3203,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -4976,6 +4979,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@next/third-parties": "^14.2.3",
         "@tanstack/react-query": "^5.28.14",
+        "@tanstack/react-query-devtools": "^5.40.1",
         "clsx": "^2.1.1",
         "next": "^14.2.2",
         "react": "^18.2.0",
@@ -554,20 +555,32 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.28.13",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.28.13.tgz",
-      "integrity": "sha512-C3+CCOcza+mrZ7LglQbjeYEOTEC3LV0VN0eYaIN6GvqAZ8Foegdgch7n6QYPtT4FuLae5ALy+m+ZMEKpD6tMCQ==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.40.0.tgz",
+      "integrity": "sha512-eD8K8jsOIq0Z5u/QbvOmfvKKE/XC39jA7yv4hgpl/1SRiU+J8QCIwgM/mEHuunQsL87dcvnHqSVLmf9pD4CiaA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.37.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.37.1.tgz",
+      "integrity": "sha512-XcG4IIHIv0YQKrexTqo2zogQWR1Sz672tX2KsfE9kzB+9zhx44vRKH5si4WDILE1PIWQpStFs/NnrDQrBAUQpg==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.28.14",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.28.14.tgz",
-      "integrity": "sha512-cZqt03Igb3I9tM72qNX5TAAmeYl75Z+k4Mv92VkXIXc2hCrv0fIywd7GN3JV1BBJl4mr7Cc+OOKKOPy8sNVOkA==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.40.1.tgz",
+      "integrity": "sha512-gOcmu+gpFd2taHrrgMM9RemLYYEDYfsCqszxCC0xtx+csDa4R8t7Hr7SfWXQP13S2sF+mOxySo/+FNXJFYBqcA==",
+      "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.28.13"
+        "@tanstack/query-core": "5.40.0"
       },
       "funding": {
         "type": "github",
@@ -575,6 +588,23 @@
       },
       "peerDependencies": {
         "react": "^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.40.1.tgz",
+      "integrity": "sha512-/AN2UsbuL+28/KSlBkVHq/4chHTEp4l2UWTKWixXbn4pprLQrZGmQTAKN4tYxZDuNwNZY5+Zp67pDfXj+F/UBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.37.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.40.1",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "debug" : "NODE_OPTIONS='--inspect' next dev"
+    "debug": "NODE_OPTIONS='--inspect' next dev"
   },
   "dependencies": {
     "@next/third-parties": "^14.2.3",
     "@tanstack/react-query": "^5.28.14",
+    "@tanstack/react-query-devtools": "^5.40.1",
     "clsx": "^2.1.1",
     "next": "^14.2.2",
     "react": "^18.2.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import QueryProvider from '@/providers/QueryProvider.tsx';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import Script from 'next/script';
 import { Metadata } from 'next';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 const PRODUCTION_URL = 'https://dev-malssami.site';
 
@@ -143,7 +144,10 @@ export default function RootLayout({
       <body className="font-pretendard">
         <div className="flex justify-center min-h-screen bg-[#FBFCFE] scrollbar-hide">
           <div className="w-full max-w-[430px] border-1 border-x border-gray-200 shadow-xl ">
-            <QueryProvider>{children}</QueryProvider>
+            <QueryProvider>
+              {children}
+              <ReactQueryDevtools initialIsOpen={false} />
+            </QueryProvider>
           </div>
         </div>
         <Script src="https://developers.kakao.com/sdk/js/kakao.js" />

--- a/src/components/common/WordItem.tsx
+++ b/src/components/common/WordItem.tsx
@@ -3,14 +3,11 @@ import { getWordDetailPath } from '@/routes/path.ts';
 import { useRouter } from 'next/navigation';
 import HeartSvg from '@/components/svg-component/HeartSvg';
 import clsx from 'clsx';
-import { useOptimisticLike } from '@/hooks/useOptimisticLike';
-import { startTransition } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
-import QUERY_KEYS from '@/constants/queryKey.ts';
+import { useMutationLike } from '@/hooks/useMutationLike';
+import { Dispatch, SetStateAction } from 'react';
 
 type Props = MainItemType & {
-  handleModal: () => void;
-  currentPage: number;
+  setIsOpenModal: Dispatch<SetStateAction<boolean>>;
 };
 
 export default function WordItem({
@@ -20,24 +17,17 @@ export default function WordItem({
   diacritic, // 발음 기호 (영문)
   pronunciation, // 발음 (국문)
   description,
-  handleModal,
-  likeCount,
-  currentPage,
+  setIsOpenModal,
 }: Props) {
   const router = useRouter();
-  const queryClient = useQueryClient();
 
-  const { optimisticLikeState, handleSubLike, handleAddLike } =
-    useOptimisticLike({
-      wordId: id,
-      isLike,
-      likeCount,
-    });
+  const { handleAddLike, handleSubLike } = useMutationLike({
+    wordId: id,
+    setIsOpenModal,
+  });
 
   const handleLikeButton = () => {
-    startTransition(() => {
-      optimisticLikeState.isLike ? handleSubLike() : handleAddLike();
-    });
+    isLike ? handleSubLike() : handleAddLike();
   };
 
   return (
@@ -72,12 +62,6 @@ export default function WordItem({
               onClick={(e) => {
                 e.stopPropagation();
                 handleLikeButton();
-                handleModal();
-
-                // NOTE: queryClient.removeQueries로 query Cache를 날리면 업데이트됩니다.
-                queryClient.removeQueries({
-                  queryKey: [QUERY_KEYS.HOME_KEY, currentPage],
-                });
               }}
               className={clsx(isLike ? 'text-main-blue' : 'text-[#D3DAED]')}
             >

--- a/src/components/pages/home/all-posts/index.tsx
+++ b/src/components/pages/home/all-posts/index.tsx
@@ -4,7 +4,6 @@ import { useState, type Dispatch, type SetStateAction } from 'react';
 import LoginAlertModal from '@/components/common/LoginAlertModal';
 import Pagination from '@/components/common/Pagination';
 import WordItem from '@/components/common/WordItem';
-import { checkUserAuthentication } from '@/fetcher';
 import { type PaginationRes, type MainItemType } from '@/types/main';
 
 type AllPostsProps = {
@@ -20,27 +19,11 @@ export default function AllPosts({
 }: AllPostsProps) {
   const [isOpenModal, setIsOpenModal] = useState(false);
 
-  const handleModal = async () => {
-    const { error } = await checkUserAuthentication();
-
-    if (error) {
-      setIsOpenModal(true);
-      setTimeout(() => {
-        setIsOpenModal(false);
-      }, 2000);
-    }
-  };
-
   return (
     // FIXME: 트렌딩 단어 오픈 후에는 아래 px-5 제거하기
     <div className="flex flex-col gap-[7px] mt-[17px] px-5">
       {data.data.map((item) => (
-        <WordItem
-          key={item.id}
-          {...item}
-          handleModal={handleModal}
-          currentPage={currentPage}
-        />
+        <WordItem key={item.id} {...item} setIsOpenModal={setIsOpenModal} />
       ))}
 
       <Pagination

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -2,6 +2,7 @@ const QUERY_KEYS = Object.freeze({
   HOME_KEY: 'posts',
   SEARCH_KEY: 'search',
   LIKEDWORD_KEY: 'likedWord',
+  AUTH_KEY: 'auth',
 } as const);
 
 export default QUERY_KEYS;

--- a/src/fetcher/index.ts
+++ b/src/fetcher/index.ts
@@ -47,7 +47,7 @@ export const updateLike = async (wordId: string) => {
     });
   } catch (e) {
     if (e instanceof Error) {
-      console.log(e.message);
+      console.error(e.message);
     }
     // 401 => 권한 없음 => 로그인 모달
     // 500 => 서버 에러
@@ -62,7 +62,7 @@ export const deleteLike = async (wordId: string) => {
     });
   } catch (e) {
     if (e instanceof Error) {
-      console.log(e.message);
+      console.error(e.message);
     }
     // NOTE: 발생할 수 있는 에러
     // 401 => 권한 없음 => 로그인 모달

--- a/src/hooks/query/useAuthQuery.ts
+++ b/src/hooks/query/useAuthQuery.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { checkUserAuthentication } from '@/fetcher';
+import QUERY_KEYS from '@/constants/queryKey';
+
+export default function useAuthQuery() {
+  return useQuery({
+    queryKey: [QUERY_KEYS.AUTH_KEY],
+    queryFn: checkUserAuthentication,
+  });
+}

--- a/src/hooks/useMutationLike.ts
+++ b/src/hooks/useMutationLike.ts
@@ -1,0 +1,60 @@
+import { addLike, subLike } from '@/actions';
+import QUERY_KEYS from '@/constants/queryKey';
+import { deleteLike, updateLike } from '@/fetcher';
+import { useQueryClient, useMutation } from '@tanstack/react-query';
+import { Dispatch, SetStateAction } from 'react';
+import useAuthQuery from './query/\buseAuthQuery';
+
+type Props = {
+  wordId: string;
+  setIsOpenModal: Dispatch<SetStateAction<boolean>>;
+};
+
+export const useMutationLike = ({ wordId, setIsOpenModal }: Props) => {
+  const queryClient = useQueryClient();
+
+  // 로그인 유무 판별
+  const { data: isLoggedIn } = useAuthQuery();
+
+  const updateLikeMutation = useMutation({
+    mutationFn: () =>
+      isLoggedIn?.error ? updateLike(wordId) : addLike(wordId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.LIKEDWORD_KEY, wordId],
+      });
+    },
+    onError: (error) => {
+      console.error('Failed to update like:', error);
+    },
+  });
+
+  const deleteLikeMutation = useMutation({
+    mutationFn: () =>
+      isLoggedIn?.error ? deleteLike(wordId) : subLike(wordId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.LIKEDWORD_KEY, wordId],
+      });
+    },
+    onError: (error) => {
+      console.error('Failed to delete like:', error);
+    },
+  });
+
+  const handleAddLike = () => {
+    if (isLoggedIn?.error) {
+      setIsOpenModal(true);
+      setTimeout(() => {
+        setIsOpenModal(false);
+      }, 2000);
+    }
+    updateLikeMutation.mutate();
+  };
+
+  const handleSubLike = () => {
+    deleteLikeMutation.mutate();
+  };
+
+  return { handleAddLike, handleSubLike };
+};

--- a/src/hooks/useMutationLike.ts
+++ b/src/hooks/useMutationLike.ts
@@ -1,4 +1,3 @@
-import { addLike, subLike } from '@/actions';
 import QUERY_KEYS from '@/constants/queryKey';
 import { deleteLike, updateLike } from '@/fetcher';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
@@ -17,11 +16,10 @@ export const useMutationLike = ({ wordId, setIsOpenModal }: Props) => {
   const { data: isLoggedIn } = useAuthQuery();
 
   const updateLikeMutation = useMutation({
-    mutationFn: () =>
-      isLoggedIn?.error ? updateLike(wordId) : addLike(wordId),
+    mutationFn: () => updateLike(wordId),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [QUERY_KEYS.LIKEDWORD_KEY, wordId],
+        queryKey: [QUERY_KEYS.HOME_KEY],
       });
     },
     onError: (error) => {
@@ -30,11 +28,10 @@ export const useMutationLike = ({ wordId, setIsOpenModal }: Props) => {
   });
 
   const deleteLikeMutation = useMutation({
-    mutationFn: () =>
-      isLoggedIn?.error ? deleteLike(wordId) : subLike(wordId),
+    mutationFn: () => deleteLike(wordId),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [QUERY_KEYS.LIKEDWORD_KEY, wordId],
+        queryKey: [QUERY_KEYS.HOME_KEY],
       });
     },
     onError: (error) => {


### PR DESCRIPTION


## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
- [x] 헤더 컴포넌트 구현 
-->
- 로그인을 판단하는 API를 사용하여 mutation 사용시 동적으로 변경하여 사용할 수 있도록 수정
## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->
### 이슈 내용: 
- 로그인을 하지 않고 좋아요 기능을 클릭할 경우 로그인 유도 토스트가 무조건 처음은 리렌더링이 한번 일어난 후에 정상적으로 동작하는 이슈가 있었습니다. 이를 해결하기 위해서는 backendFetch를 사용해서 좋아요 취소하기를 해야했습니다. (왜인지는 정확히 모르겠지만 serverFetch를 할 경우에만 리렌더링 이슈가 발생했기 때문입니다.)
- 단, 로그인 후에도 backendFetch를 사용하여 좋아요 api를 사용할 경우에는 실제로 네트워크 통신은 일어나는데도 불구하고 ui의 즉각적 반응이 이루어지지 않는 이슈가 있었습니다.  이를 해결하기 위해 로그인 후에는 serverFetch를 사용하였습니다. (이유는 위와 같습니다.)
### 결과
- 이 같이 구현한 결과 우선 기능 자체는 정상적으로 작동합니다. 
- 다만 server component를 사용하기 위해(?) 이러한 불필요한 로직을 종속적으로 따를 수 밖에 없다는  것에 의문이 좀 많이 들긴하네요.. (물론 다른 해결방식이 있는데, 제가 모르고 이상한 방식으로 구현한것 일수도 있습니다!!)

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->

## 📌 구현 결과
<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->