### PR TITLE
feat: 비로그인 시 로그인 토스트 UI 로직 추가

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -11,9 +11,8 @@ export const addLike = async (wordId: string) => {
     });
   } catch (e) {
     console.log(e);
-
     // NOTE: 발생할 수 있는 에러
-    // 401 => 권한 없음 => 로그인 모달
+    // 401 => 권한 없음
     // 500 => 서버 에러
   }
 
@@ -27,11 +26,10 @@ export const subLike = async (wordId: string) => {
     });
   } catch (e) {
     console.log(e);
-
     // NOTE: 발생할 수 있는 에러
-    // 401 => 권한 없음 => 로그인 모달
+    // 401 => 권한 없음
     // 500 => 서버 에러
   }
-
+  // NOTE: refresh하고 싶은 path를 작성
   revalidatePath(`word/${wordId}`);
 };

--- a/src/components/pages/detail/LikeButton.tsx
+++ b/src/components/pages/detail/LikeButton.tsx
@@ -3,6 +3,9 @@
 import DetailLikeSvg from '@/components/svg-component/DetailLikeSvg.tsx';
 import DetailLikeActiveSvg from '@/components/svg-component/DetailLikeActiveSvg.tsx';
 import { useOptimisticLike } from '@/hooks/useOptimisticLike.ts';
+import useAuthQuery from '@/hooks/query/useAuthQuery.ts';
+import { useState } from 'react';
+import LoginAlertModal from '@/components/common/LoginAlertModal.tsx';
 
 interface Props {
   wordId: string;
@@ -15,6 +18,8 @@ export default function LikeButton({
   initialLikeCount,
   wordId,
 }: Props) {
+  const { data: isLoggedIn } = useAuthQuery();
+  const [isOpenModal, setIsOpenModal] = useState(false);
   const { optimisticLikeState, handleSubLike, handleAddLike } =
     useOptimisticLike({
       wordId,
@@ -24,12 +29,24 @@ export default function LikeButton({
 
   // TODO: loading 시 클릭 안되게 할 필요 있음
 
+  function handleClick(isLike: boolean) {
+    // NOTE: 2초간 로그인 toast UI
+    if (isLoggedIn?.error) {
+      setIsOpenModal(true);
+      setTimeout(() => {
+        setIsOpenModal(false);
+      }, 2000);
+
+      return;
+    }
+
+    isLike ? handleSubLike() : handleAddLike();
+  }
+
   return (
     <>
       <div className="flex flex-col justify-center items-center cursor-pointer">
-        <button
-          onClick={optimisticLikeState.isLike ? handleSubLike : handleAddLike}
-        >
+        <button onClick={() => handleClick(optimisticLikeState.isLike)}>
           {optimisticLikeState.isLike ? (
             <DetailLikeActiveSvg />
           ) : (
@@ -40,7 +57,7 @@ export default function LikeButton({
           {optimisticLikeState.likeCount}
         </span>
       </div>
-      {/*<LoginAlertModal isOpen={true} />*/}
+      <LoginAlertModal isOpen={isOpenModal} />
     </>
   );
 }

--- a/src/hooks/useOptimisticLike.ts
+++ b/src/hooks/useOptimisticLike.ts
@@ -8,8 +8,6 @@ interface Props {
   likeCount: number;
 }
 export const useOptimisticLike = ({ wordId, isLike, likeCount }: Props) => {
-  // const addLikeMutation = useAddLike(wordId);
-  // const deleteLikeMutation = useDeleteLike(wordId);
   const [optimisticLikeState, setOptimisticLike] = useOptimistic<
     {
       isLike: boolean;


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
- [x] 헤더 컴포넌트 구현 
-->
- [x] 비로그인 시 로그인 토스트 UI 로직 추가
## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->

###  비로그인 시 로그인 토스트 UI 로직 추가
덕배가 만들어주신 LoginAlartModal 컴포넌트를 활용해 해당 로직을 추가했습니다. 
다만 추후 해당 부분 리팩토링이 필요할 듯합니다. 
현재 함수 error 처리 부분이나 재사용성 부분이 조금 부족하다고 생각이 드네요! 

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->

## 📌 구현 결과
<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->

릴리즈 이후 에러 및 response 로직 공통화 논의와 함께 리팩토링 진행하면 좋겠습니다.! 