### PR TITLE
[DEV-98] 단어장 페이지에 비로그인 상태로 진입하면 로그인 페이지로 redirect하도록 처리

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,13 +6,7 @@ import { GoogleAnalytics } from '@next/third-parties/google';
 import Script from 'next/script';
 import { Metadata } from 'next';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-
-const PRODUCTION_URL = 'https://dev-malssami.site';
-
-const baseUrl =
-  process.env.NODE_ENV === 'production'
-    ? PRODUCTION_URL
-    : process.env.NEXT_PUBLIC_BASE_URL;
+import { BASE_URL, PRODUCTION_URL } from '@/utils';
 
 // eslint-disable-next-line react-refresh/only-export-components
 export const metadata: Metadata = {
@@ -31,7 +25,7 @@ export const metadata: Metadata = {
     index: true,
     follow: true,
   },
-  metadataBase: new URL(baseUrl || PRODUCTION_URL),
+  metadataBase: new URL(BASE_URL || PRODUCTION_URL),
   openGraph: {
     title: {
       template: '데브말싸미 | %s',
@@ -39,7 +33,7 @@ export const metadata: Metadata = {
     },
     description:
       '발음이 헷갈리는 개발 용어에 대해 손쉽게 발음과 뜻을 검색해보세요.',
-    url: baseUrl,
+    url: BASE_URL,
     siteName: '데브말싸미',
     type: 'website',
     locale: 'ko_KR',

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,12 +6,18 @@ import {
 } from 'next/dist/server/web/spec-extension/cookies';
 import { serverFetch } from '@/fetcher/serverFetch.ts';
 import type { FetchRes, DefaultRes } from '@/fetcher/types.ts';
+import { BASE_URL } from './utils';
 
 export async function middleware(request: NextRequest) {
   const accessToken = request.cookies.get('accessToken')?.value;
   const refreshToken = request.cookies.get('refreshToken')?.value;
+  const { pathname } = request.nextUrl;
 
   const next = NextResponse.next();
+
+  // 비로그인 상태로 단어장 페이지에 진입할 경우 "/"으로 redirect
+  if (pathname === '/user/wordbook' && !accessToken && !refreshToken)
+    return NextResponse.redirect(new URL('/', BASE_URL));
 
   // accessToken이 없고 refreshToken이 있을 경우
   if (!accessToken && refreshToken) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,10 @@
 export function isServer() {
   return typeof window === 'undefined';
 }
+
+export const PRODUCTION_URL = 'https://dev-malssami.site';
+
+export const BASE_URL =
+  process.env.NODE_ENV === 'production'
+    ? PRODUCTION_URL
+    : process.env.NEXT_PUBLIC_BASE_URL;


### PR DESCRIPTION
## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->

- [x] 배포환경 URL과 개발환경 URL을 상수로 지정했습니다. env로 넣어도 되지만 일단 현재 상수 처리 해주었습니다! 
- [x] 비로그인 상태로 단어장 페이지 URL에 접근하면 로그인 페이지로 redirect하도록 미들웨어에서 처리해주었습니다.
- [ ] 마이페이지에서 단어장 페이지로 접근할 때는 모달 처리 필요 (비로그인 상태로 현재 헤더에 있는 햄버거 버튼을 클릭하면 바로 로그인페이지로 redirect되고 있습니다.)

## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->

네이버 사전의 단어장과 다음 사전의 단어장도 비로그인상태에서 단어장 URL로 접근하면 바로 로그인 페이지로 redirect하더라구요!
근데 마이페이지에서 단어장으로 접근할 때처럼 모달을 띄우지 않는게 갑자기 뭔가 어색하게 느껴졌어요,, 유저가 어색하게 느끼지 않을까,, 하지만 이게 보편적인 방법이겠죠?!