### PR TITLE
[DEV-97] WordItem 높이 가변적으로 동작하도록 수정 및 Searchbar 컴포넌트 Dropdown 아닐시 border 제거

### DIFF
--- a/src/components/common/WordItem.tsx
+++ b/src/components/common/WordItem.tsx
@@ -33,7 +33,7 @@ export default function WordItem({
   return (
     <article
       key={id}
-      className="h-[98px] p-4 w-full ring-1 bg-white ring-[#F2F4F9] hover:ring-[#EFF2F7] rounded-2xl hover:bg-[#F1F4FA] hover:ring-2 cursor-pointer"
+      className="min-h-[98px] p-4 w-full ring-1 bg-white ring-[#F2F4F9] hover:ring-[#EFF2F7] rounded-2xl hover:bg-[#F1F4FA] hover:ring-2 cursor-pointer"
       onClick={() => router.push(getWordDetailPath(name))}
     >
       <div className="flex flex-col relative ">

--- a/src/components/layout/SearchBar.tsx
+++ b/src/components/layout/SearchBar.tsx
@@ -140,8 +140,8 @@ export default function SearchBar({ word }: Props) {
     >
       <div
         className={clsx(
-          'relative border-[2px] border-[#4357DB] rounded-[16px] z-[60]',
-          isDropdown && 'bg-white',
+          'relative rounded-[16px] z-[60]',
+          isDropdown && 'bg-white border-[2px] border-[#4357DB]',
         )}
         ref={searchBarRef}
       >


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
- [x] 헤더 컴포넌트 구현 
-->

## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->
- WordItem 높이 가변적으로 동작하도록 수정
- Searchbar 컴포넌트 Dropdown 아닐시 border 제거

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->

## 📌 구현 결과
<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->