### PR TITLE
[DEV-107]fix: 퀴즈 결과 페이지 기획 & 디자인과 일치하도록 수정 & 노트 애니메이션 추가

### DIFF
--- a/src/components/common/ShareModal.tsx
+++ b/src/components/common/ShareModal.tsx
@@ -11,7 +11,10 @@ import { useRouter } from 'next/navigation';
 export default function ShareModal() {
   const { handleShare } = useLoadKakaoScript();
   const router = useRouter();
-  const { isCopied, onCopyClipboard } = useCopyClipboard();
+  const shareURL = window.location.href;
+  const { isCopied, onCopyClipboard } = useCopyClipboard({
+    url: shareURL,
+  });
 
   return (
     <div className="fixed max-w-[430px] top-0 w-full h-full flex justify-center items-center bg-[#17192470] px-[46px]">

--- a/src/components/pages/quiz/QuizResult.tsx
+++ b/src/components/pages/quiz/QuizResult.tsx
@@ -54,7 +54,7 @@ export default function QuizResult({
         >
           <BlackBackSpaceSVG />
         </button>
-        <div className="m-auto font-medium pr-3">TEST 결과</div>
+        <div className="m-auto font-medium">TEST 결과</div>
         <button onClick={handleShare}>
           <ShareButtonSvg />
         </button>

--- a/src/components/pages/quiz/QuizResult.tsx
+++ b/src/components/pages/quiz/QuizResult.tsx
@@ -28,6 +28,7 @@ export default function QuizResult({
   const { data } = useAuthQuery();
   const [isOpenModal, setIsOpenModal] = useState(false);
   const isLoggedIn = !data?.error ?? false;
+  const isGuest = quizResultId === 'guest';
 
   const handleNeedLogin = () => {
     // NOTE: 2초간 로그인 toast UI
@@ -68,7 +69,11 @@ export default function QuizResult({
         onClick={() => router.replace(QUIZ_PATH)}
         className="bg-[#4057DB] rounded-[16px] mt-[24px] mb-[48px] h-[50px] font-semibold text-white w-full text-[16px]"
       >
-        다시 도전하러 가기
+        {data?.error && !isGuest ? (
+          <span>나도 도전하러 가기</span>
+        ) : (
+          <span>다시 도전하러 가기</span>
+        )}
       </button>
       <LoginAlertModal isOpen={isOpenModal} />
     </div>

--- a/src/components/pages/quiz/QuizResultDetail.tsx
+++ b/src/components/pages/quiz/QuizResultDetail.tsx
@@ -3,6 +3,7 @@ import ArrowUpSvg from '@/components/svg-component/ArrowUpSvg';
 import { useState } from 'react';
 import type { QuizResultWordData } from '@/fetcher/types';
 import QuizResultDetailWord from './QuizResultDetailWord';
+import clsx from 'clsx';
 
 type Props = {
   correctWords: QuizResultWordData[];
@@ -20,51 +21,57 @@ export default function QuizResultDetail({
   };
 
   return (
-    <>
+    <div className="relative">
       {isDetail ? (
-        <button
-          className="w-full h-[60px] mt-[-10px] bg-[#F2F4F9] rounded-b-[16px] flex justify-center items-center text-[16px] text-[#383697] font-semibold"
-          onClick={handleIsDetailChange}
-        >
-          퀴즈 결과 자세히 보기
-          <ArrowDownSvg />
-        </button>
-      ) : (
-        <>
-          <div className="w-full bg-[#F2F4F9]">
-            <div className="relative flex justify-between px-[34px] mt-[-20px] z-9999">
-              <span className="h-[24px] border border-l-[6px] border-[#ABB9D5] rounded-md"></span>
-              <span className="h-[24px] mr-[224px] border border-l-[6px] border-[#ABB9D5] rounded-md"></span>
-              <span className="h-[24px] border border-l-[6px] border-[#ABB9D5] rounded-md"></span>
-              <span className="h-[24px] border border-l-[6px] border-[#ABB9D5] rounded-md"></span>
-            </div>
-            <div className="flex justify-between items-center px-5 pt-[40px]">
-              <span className="text-[20px] font-semibold">
-                퀴즈 정답이에요!
-              </span>
-              <div className="inline-block space-x-1">
-                <span className="inline-block h-2 w-2 rounded-full bg-quiz-blue"></span>
-                <span className="text-[11px] pr-2">맞았어요</span>
-                <span className="inline-block h-2 w-2 rounded-full bg-quiz-red"></span>
-                <span className="text-[11px]">틀렸어요</span>
-              </div>
-            </div>
-            {words.map((data) => (
-              <QuizResultDetailWord
-                key={data.wordId}
-                data={data}
-                correctWords={correctWords}
-              />
-            ))}
+        <div className="absolute w-full -top-[12px] flex justify-between">
+          <div className="flex gap-6 pl-[34px]">
+            <span className="h-[24px] border border-l-[6px] border-[#ABB9D5] rounded-md" />
+            <span className="h-[24px] border border-l-[6px] border-[#ABB9D5] rounded-md" />
           </div>
-          <button
-            className="w-full h-[64px] bg-[#F2F4F9] rounded-b-[16px] flex justify-center items-center text-[16px] text-[#383697] font-semibold"
-            onClick={handleIsDetailChange}
-          >
-            퀴즈 결과 접기 <ArrowUpSvg />
-          </button>
-        </>
-      )}
-    </>
+          <div className="flex gap-6 pr-[34px]">
+            <span className="h-[24px] border border-l-[6px] border-[#ABB9D5] rounded-md" />
+            <span className="h-[24px] border border-l-[6px] border-[#ABB9D5] rounded-md" />
+          </div>
+        </div>
+      ) : null}
+      <div
+        className={`w-full bg-[#F2F4F9] ${clsx(isDetail ? 'max-h-[100vh]' : 'max-h-[0px]')} transition-all overflow-hidden`}
+      >
+        <div className="flex justify-between items-center px-5 pt-[40px]">
+          <span className="text-[20px] font-semibold">퀴즈 정답이에요!</span>
+          <div className="inline-block space-x-1">
+            <span className="inline-block h-2 w-2 rounded-full bg-quiz-blue"></span>
+            <span className="text-[11px] pr-2">맞았어요</span>
+            <span className="inline-block h-2 w-2 rounded-full bg-quiz-red"></span>
+            <span className="text-[11px]">틀렸어요</span>
+          </div>
+        </div>
+        {words.map((data) => (
+          <QuizResultDetailWord
+            key={data.wordId}
+            data={data}
+            correctWords={correctWords}
+          />
+        ))}
+      </div>
+      <button
+        className="w-full h-[64px] bg-[#F2F4F9] rounded-b-[16px] flex justify-center items-center text-[16px] text-[#383697] font-semibold"
+        onClick={handleIsDetailChange}
+      >
+        <div className="flex justify-center items-center gap-2">
+          {isDetail ? (
+            <>
+              <span>퀴즈 결과 접기</span>
+              <ArrowUpSvg />
+            </>
+          ) : (
+            <>
+              <span>퀴즈 결과 보기</span>
+              <ArrowDownSvg />
+            </>
+          )}
+        </div>
+      </button>
+    </div>
   );
 }

--- a/src/components/pages/quiz/QuizResultDetailWord.tsx
+++ b/src/components/pages/quiz/QuizResultDetailWord.tsx
@@ -6,6 +6,8 @@ import Heart1Svg from '@/components/svg-component/Heart1Svg';
 import { useOptimisticLike } from '@/hooks/useOptimisticLike';
 import useAuthQuery from '@/hooks/query/useAuthQuery.ts';
 import LoginAlertModal from '@/components/common/LoginAlertModal.tsx';
+import { getWordDetailPath } from '@/routes/path.ts';
+import { useRouter } from 'next/navigation';
 
 type Props = {
   data: QuizResultWordData;
@@ -13,6 +15,8 @@ type Props = {
 };
 
 export default function QuizResultDetailWord({ data, correctWords }: Props) {
+  const router = useRouter();
+
   const { data: authData } = useAuthQuery();
   const [isOpenModal, setIsOpenModal] = useState(false);
   const isLoggedIn = !authData?.error ?? false;
@@ -32,7 +36,11 @@ export default function QuizResultDetailWord({ data, correctWords }: Props) {
     }, 2000);
   };
 
-  const handleLikeClick = () => {
+  const handleLikeClick = (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+  ) => {
+    e.stopPropagation();
+
     if (isLoggedIn) {
       startTransition(() => {
         optimisticLikeState.isLike ? handleSubLike() : handleAddLike();
@@ -42,8 +50,15 @@ export default function QuizResultDetailWord({ data, correctWords }: Props) {
     }
   };
 
+  const handleClickWordDetail = () => {
+    router.push(getWordDetailPath(data.name));
+  };
+
   return (
-    <div className="flex flex-col mt-[14px] mx-5 border-b-2">
+    <div
+      className="flex flex-col mt-[14px] mx-5 border-b-2 cursor-pointer"
+      onClick={handleClickWordDetail}
+    >
       <div className="flex items-center justify-between pb-3">
         <div>
           <div

--- a/src/components/pages/quiz/QuizScore.tsx
+++ b/src/components/pages/quiz/QuizScore.tsx
@@ -6,10 +6,11 @@ type Props = {
 
 export default function QuizScore({ score }: Props) {
   return (
-    <div className="w-full aspect-square relative flex justify-center">
+    <div className="w-full max-h-[374px] overflow-hidden relative flex justify-center">
       <div className="absolute top-[30%] text-center">
         <p>
           <span className="font-semibold text-[#313140] text-[18px] mr-1">
+            {/*{FIXME: quiz result에서 사용자 이름 추가되면 사용자 이름 받아오기}*/}
             사용자
           </span>
           <span className="text-[#313140] font-medium">

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -4,6 +4,7 @@ const QUERY_KEYS = Object.freeze({
   SEARCH_KEY: 'search',
   LIKEDWORD_KEY: 'likedWord',
   AUTH_KEY: 'auth',
+  USER_KEY: 'user',
 } as const);
 
 export default QUERY_KEYS;

--- a/src/fetcher/index.ts
+++ b/src/fetcher/index.ts
@@ -8,8 +8,8 @@ import type {
   UserInfo,
   ErrorResponse,
   AutoCompleteWord,
-    QuizData,
-    QuizResultUserIdData
+  QuizData,
+  QuizResultUserIdData,
 } from './types.ts';
 import { PaginationRes, MainItemType } from '@/types/main.ts';
 import { backendFetch } from '@/fetcher/backendFetch.ts';

--- a/src/hooks/query/useGetUser.ts
+++ b/src/hooks/query/useGetUser.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { getUserInfo } from '@/fetcher';
+import QUERY_KEYS from '@/constants/queryKey';
+
+export default function useGetUser() {
+  return useQuery({
+    queryKey: [QUERY_KEYS.USER_KEY],
+    queryFn: getUserInfo,
+  });
+}

--- a/src/hooks/useCopyClipboard.ts
+++ b/src/hooks/useCopyClipboard.ts
@@ -1,26 +1,35 @@
 import { useEffect, useState } from 'react';
 
-async function copyURL() {
-  const url = window.document.location.href;
-  await navigator.clipboard.writeText(url);
+async function copyURL(url?: string) {
+  const targetUrl = url ? url : window.document.location.href;
+  await navigator.clipboard.writeText(targetUrl);
+}
+interface Props {
+  ms?: number;
+  url?: string;
 }
 
-export default function useCopyClipboard(ms = 600) {
+const DEFAULT_COPIED_ALERT_TIME = 600;
+
+export default function useCopyClipboard(props?: Props) {
   const [isCopied, setIsCopied] = useState(false);
 
   useEffect(() => {
     let id: NodeJS.Timeout | null;
     if (isCopied) {
-      id = setTimeout(() => setIsCopied(false), ms ?? 600);
+      id = setTimeout(
+        () => setIsCopied(false),
+        props?.ms ?? DEFAULT_COPIED_ALERT_TIME,
+      );
     }
 
     return () => {
       if (id) clearTimeout(id);
     };
-  }, [isCopied, ms]);
+  }, [isCopied, props?.ms]);
 
   const onCopyClipboard = async () => {
-    await copyURL();
+    await copyURL(props?.url);
     setIsCopied(true);
   };
 


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
- [x] 헤더 컴포넌트 구현 
-->
- [x] 디자인과 구현이 다른 부분 수정 (노트 부분)
- [X] 노트 접었다 펼쳐지는 부분 애니메이션 (트렌지션 추가)
- [X] 퀴즈 공유 URL 수정 
- [X] 퀴즈 단어 클릭 시 디테일 페이지로 넘어가도록 기능 추가

## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->

 퀴즈 공유 페이지에서 디자인과 구현이 다른 부분을 수정했습니다. (노트 스프링 디자인)
 css transition으로 퀴즈가 접히고 펴질 때 애니메이션을 추가했습니다. 
퀴즈 공유 URL 수정이 잘못되어있어서, 수정했습니다. useCopyClipboard 훅에 특정 url을 넣을 수 있도록 만들어서, 현재 URL이 아니어도 클립보드에 넣어준 url이 복사될 수 있도록 만들었습니다. 


<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->

## 📌 구현 결과
<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->
<img width="467" alt="Screenshot 2024-06-19 at 3 27 41 PM" src="https://github.com/Devminjeong-eum/frontend/assets/75849590/a6b1a316-2333-443c-9011-55c8ed432872">

## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->