### PR TITLE
feat: 로그인 페이지 진입 시 로그인된 유저면 home으로 redirect

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -2,7 +2,6 @@ import Spinner from '@/components/common/Spinner';
 import Header from '@/components/layout/Header';
 import HomeClientPage from '@/components/pages/home';
 import QUERY_KEYS from '@/constants/queryKey';
-import { getAllPostsServer } from '@/fetcher';
 
 import {
   HydrationBoundary,
@@ -11,6 +10,7 @@ import {
 } from '@tanstack/react-query';
 import { Suspense } from 'react';
 import { cookies } from 'next/headers';
+import { getAllPostsServer } from '@/fetcher/server.ts';
 
 export default async function HomePage({
   searchParams: { page },

--- a/src/fetcher/index.ts
+++ b/src/fetcher/index.ts
@@ -14,7 +14,6 @@ import type {
 import { PaginationRes, MainItemType } from '@/types/main.ts';
 import { backendFetch } from '@/fetcher/backendFetch.ts';
 import { FetchRes } from './types.ts';
-import { serverFetch } from './serverFetch.ts';
 
 export const getWordSearch = async (wordName: string) => {
   try {
@@ -86,24 +85,6 @@ export const getAllPostsClient = async (currentPage: number) => {
 
     return res.data;
   } catch (e) {
-    notFound();
-  }
-};
-
-export const getAllPostsServer = async (currentPage: number) => {
-  try {
-    const res = await serverFetch<
-      FetchRes<DefaultRes<PaginationRes<MainItemType[]>>>
-    >(`/word/list`, {
-      params: {
-        page: currentPage,
-        limit: 10,
-      },
-    });
-
-    return res.data;
-  } catch (e) {
-    console.log('error', e);
     notFound();
   }
 };

--- a/src/fetcher/server.ts
+++ b/src/fetcher/server.ts
@@ -1,0 +1,26 @@
+import { serverFetch } from '@/fetcher/serverFetch.ts';
+import { DefaultRes, FetchRes, UserData } from '@/fetcher/types.ts';
+import { MainItemType, PaginationRes } from '@/types/main.ts';
+import { notFound } from 'next/navigation';
+
+export const getAllPostsServer = async (currentPage: number) => {
+  try {
+    const res = await serverFetch<
+      FetchRes<DefaultRes<PaginationRes<MainItemType[]>>>
+    >(`/word/list`, {
+      params: {
+        page: currentPage,
+        limit: 10,
+      },
+    });
+
+    return res.data;
+  } catch (e) {
+    console.log('error', e);
+    notFound();
+  }
+};
+
+export const getUserInfoServer = async () => {
+  return await serverFetch<FetchRes<DefaultRes<UserData>>>(`/user`);
+};


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
- [x] 헤더 컴포넌트 구현 
-->
- [x] 로그인된 유저면 home 페이지로 리다이렉트시킴
## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->
middleware를 통해서 리다이렉트를 구현했습니다. 

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->
 
해당 코드 부분이고, serverFetch를 사용했습니다. 
```js
  // 로그인 상태일 경우 로그인 화면 접근 시 홈으로 리다이렉트
  console.log(request.url);
  if (request.url === `${baseUrl}/` && accessToken && refreshToken) {
    try {
      await getUserInfoServer();
      console.log('로그인된 유저입니다. 홈으로 이동합니다');
      return NextResponse.redirect(`${baseUrl}/home?view=all&page=1`);
    } catch (e) {
      console.log('정상적이지 않은 토큰이거나, 서버 에러입니다.', e);
      // pass through
    }
  }

```

## 📌 구현 결과
<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->