### PR TITLE
fix: 단어장 페이지 디자인 QA 반영

### DIFF
--- a/src/components/pages/wordbook/WordbookDropdown.tsx
+++ b/src/components/pages/wordbook/WordbookDropdown.tsx
@@ -1,5 +1,6 @@
 import ArrowDownSvg from '@/components/svg-component/ArrowDownSvg';
 import { dropdownOptions } from '@/constants/sortingOptions';
+import clsx from 'clsx';
 import { Dispatch, SetStateAction } from 'react';
 
 interface Props {
@@ -21,7 +22,12 @@ export default function WordbookDropdown({
         {dropdownOptions.map((option, index) => (
           <li
             key={index}
-            className="p-1 hover:bg-[#F1F4FA] focus:bg-[#F1F4FA] focus:rounded-lg hover:rounded-lg"
+            className={clsx(
+              'p-1 hover:bg-[#F1F4FA] focus:bg-[#F1F4FA] focus:rounded-lg hover:rounded-lg',
+              selectedOption === option
+                ? 'text-main-blue font-semibold'
+                : 'font-normal',
+            )}
             onClick={() => setSelectedOption(option)}
           >
             {option}

--- a/src/components/pages/wordbook/index.tsx
+++ b/src/components/pages/wordbook/index.tsx
@@ -36,7 +36,7 @@ export default function Wordbook() {
           <div className="flex">
             <div className="w-[calc(46%+30px)] h-9 overflow-hidden rounded-tl-xl relative top-px">
               <div className="bg-[#FBFCFE] [transform:rotateY(180deg)_skew(-30deg)_translate(30px,0px)] h-full rounded-tl-md flex justify-center items-center">
-                <div className="[transform:rotateY(180deg)_skew(-30deg)_translate(-40px,0px)] pl-2.5 text-[#313140] font-medium text-sm leading-[18px] tracking-[-0.02em] opacity-90">
+                <div className="[transform:rotateY(180deg)_skew(-30deg)_translate(-40px,0px)] pl-2.5 text-[#313140] font-medium text-[15px] leading-[18px] tracking-[-0.02em] opacity-90">
                   총 {totalCount}개
                 </div>
               </div>


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
- [x] 헤더 컴포넌트 구현 
-->

단어장 페이지 디자인 QA 내역 반영

## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->

- 단어 총 개수 글자크기 수정
- 드롭다운 font-weight, font-color 수정

## 📌 구현 결과
<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

![image](https://github.com/Devminjeong-eum/frontend/assets/55550034/fcf4fe61-c1c7-40ec-93b9-f393dc7c5bb2)
![image](https://github.com/Devminjeong-eum/frontend/assets/55550034/f4c202ff-985f-4bde-9c0e-7f300464b584)


## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->