### PR TITLE
[DEV-121] fix: quiz 결과 누적 수정(atom 초기화)

### DIFF
--- a/src/components/pages/quiz/index.tsx
+++ b/src/components/pages/quiz/index.tsx
@@ -5,12 +5,27 @@ import ScoreSVG from '@/components/svg-component/ScoreSvg';
 import QuizPlay from './QuizPlay';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useSetAtom } from 'jotai/react';
+import { guestQuizAtom } from '@/store';
 
 export default function Quiz() {
   const [isShow, setIsShow] = useState(false);
   const router = useRouter();
+  const setQuizAtom = useSetAtom(guestQuizAtom);
 
-  if (isShow) return <QuizPlay />;
+  const handleClickPlayButton = () => {
+    setQuizAtom(() => {
+      return {
+        correctWordData: [],
+        incorrectWordData: [],
+      };
+    });
+    setIsShow(true);
+  };
+
+  if (isShow) {
+    return <QuizPlay />;
+  }
 
   return (
     <div className="px-5 h-screen flex flex-col justify-center items-center bg-main-gradient-full relative">
@@ -31,7 +46,7 @@ export default function Quiz() {
         <p className="text-white font-medium">나의 개발 용어 발음 지식은?</p>
       </div>
       <button
-        onClick={() => setIsShow(true)}
+        onClick={handleClickPlayButton}
         className="w-[calc(100%-40px)] flex justify-center items-center absolute bottom-[50px] h-12 rounded-[16px] bg-white/20 ring-1 ring-white/40 focus:ring-white/60 outline-none text-white
         shadow-quiz
         hover:cursor-pointer"


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
- [x] 헤더 컴포넌트 구현 
-->
- [x] 퀴즈를 여러번 풀면 결과가 누적되는 버그 수정

## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->
전역 상태 초기화로 버그 수정 
<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->

## 📌 구현 결과
<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->