### PR TITLE
fix: 퀴즈 페이지 내 헤더 텍스트를 개발 용어 발음 퀴즈로 수정

### DIFF
--- a/src/components/layout/SearchBar.tsx
+++ b/src/components/layout/SearchBar.tsx
@@ -31,12 +31,12 @@ export default function SearchBar() {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const handleSearchBarOutsideClick = () => {
-    if (searchInput.length) {
-      setIsDropdownOpen(false);
-      return;
+    setIsDropdownOpen(false);
+    
+    if (!searchInput) {
+      setIsInputFocus(false);
+      setWordSearchResult(null);
     }
-    setIsInputFocus(false);
-    setWordSearchResult(null);
   };
 
   const { targetRef: searchBarRef } = useOnClickOutside<HTMLDivElement>({

--- a/src/components/pages/quiz/QuizPlay.tsx
+++ b/src/components/pages/quiz/QuizPlay.tsx
@@ -115,7 +115,7 @@ export default function QuizPlay() {
             >
               <BlackBackSpaceSVG />
             </button>
-            <div className=" m-auto font-medium pr-6">TEST 중이에요.</div>
+            <div className=" m-auto font-medium pr-6">개발 용어 발음 퀴즈</div>
           </header>
           <div className={`w-full bg-[#ECEFF5] flex`}>
             <div


### PR DESCRIPTION
## 📌 기능 설명
- [x] 퀴즈 페이지 내 헤더 텍스트를 개발 용어 발음 퀴즈로 수정
- [x] 검색 바에 텍스트를 비운 후 Focus - Out 진행 시 스타일링이 올바르게 적용되도록 수정했습니다

## 📌 구현 내용
퀴즈 페이지 내 헤더 텍스트를 "개발 용어 발음 퀴즈" 로 수정했습니다.

## 📌 구현 결과
![2222](https://github.com/Devminjeong-eum/frontend/assets/74497253/7029fbc2-4e3b-40fb-b595-0f0617ae5115)