### PR TITLE
[DEV-130] 트렌딩 단어 순위 API 연동 및 컴포넌트 수정

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -10,7 +10,10 @@ import {
 } from '@tanstack/react-query';
 import { Suspense } from 'react';
 import { cookies } from 'next/headers';
-import { getAllPostsServer } from '@/fetcher/server.ts';
+import {
+  getAllPostsServer,
+  getCurrentWeekTrendList,
+} from '@/fetcher/server.ts';
 
 export default async function HomePage({
   searchParams: { page },
@@ -19,10 +22,16 @@ export default async function HomePage({
 }) {
   const queryClient = new QueryClient();
 
-  await queryClient.prefetchQuery({
-    queryFn: () => getAllPostsServer(Number(page)),
-    queryKey: [QUERY_KEYS.HOME_KEY, Number(page)],
-  });
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryFn: () => getAllPostsServer(Number(page)),
+      queryKey: [QUERY_KEYS.HOME_KEY, Number(page)],
+    }),
+    queryClient.prefetchQuery({
+      queryFn: () => getCurrentWeekTrendList(),
+      queryKey: [QUERY_KEYS.TREND],
+    }),
+  ]);
 
   const isToken = cookies().has('accessToken');
 

--- a/src/components/pages/home/trending-posts/GeneralRanking.tsx
+++ b/src/components/pages/home/trending-posts/GeneralRanking.tsx
@@ -1,37 +1,42 @@
-import FillArrowSvg from '@/components/svg-component/FillArrowSvg';
+import { TrendWord } from '@/fetcher/types';
 import clsx from 'clsx';
+import { RankChange } from './RankChange';
 
-export default function GeneralRanking() {
-  const dummyItems = [4, 5, 6, 7, 8, 9, 10];
+type Props = {
+  generalRankingList: TrendWord[];
+};
 
+export default function GeneralRanking({ generalRankingList }: Props) {
   return (
     <div className="w-full mt-[22px] border-[#F2F4F9] border-[1px] rounded-2xl px-4 py-[22px]">
-      {dummyItems.map((item, index) => (
+      {generalRankingList.map((trendWord, index) => (
         <div
           key={index}
           className={clsx(
             'h-[54px] border-[#ECEEF5] border-b-[1px] w-full flex items-center',
             index === 0 && '-mt-[6px]',
-            index === dummyItems.length - 1 && 'border-none',
+            index === 6 && 'border-none',
           )}
         >
           {/* 순위 */}
           <p className="font-semibold text-[#AAB2D0] text-[11px] ml-[20px]">
-            {item}
+            {trendWord.rank}
           </p>
 
           {/* 영단어 컨테이너 */}
           <span className="flex ml-[29px] gap-[6px] flex-1 items-end ">
-            <p className="text-[16px] text-main-black">{item}</p>
+            <p className="text-[16px] text-main-black">{trendWord.name}</p>
             <span className="text-[#F2F4F9]">|</span>
-            <p className="text-[#6F6F80] text-[14px]">{item}</p>
+            <p className="text-[#6F6F80] text-[14px]">
+              {trendWord.pronunciation}
+            </p>
           </span>
 
           {/* 순위 등락 컨테이너  */}
-          <div className="mr-[22px] bg-[#F4F6FB] rounded-xl w-[34px] h-[17px] px-[3px] text-main-blue flex items-center justify-center">
-            <FillArrowSvg />
-            <p className="text-[10px]">{item}</p>
-          </div>
+          <RankChange
+            className="bg-[#F4F6FB] text-main-blue"
+            rankChange={trendWord.rankChange}
+          />
         </div>
       ))}
     </div>

--- a/src/components/pages/home/trending-posts/RankChange.tsx
+++ b/src/components/pages/home/trending-posts/RankChange.tsx
@@ -1,0 +1,53 @@
+import clsx from 'clsx';
+
+import FillArrowSvg from '@/components/svg-component/FillArrowSvg';
+import HyphenSvg from '@/components/svg-component/HyphenSvg';
+
+type Props = {
+  className: string;
+  innerClassName?: string;
+  rankChange?: number;
+};
+
+export const RankChange = ({
+  className,
+  innerClassName,
+  rankChange,
+}: Props) => {
+  const isNew = typeof rankChange !== 'number';
+  const isSame = !isNew && rankChange === 0;
+  const isChanged = !isNew && rankChange !== 0;
+
+  console.log({
+    isNew,
+    isSame,
+    isChanged,
+  });
+
+  return (
+    <div
+      className={clsx(
+        'mr-[22px] rounded-xl w-[34px] h-[17px] px-[3px] flex items-center justify-center',
+        className,
+      )}
+    >
+      {isNew && (
+        <p className={clsx(innerClassName, 'text-[11px] text-[#6C55F8]')}>
+          New
+        </p>
+      )}
+      {isSame && <HyphenSvg className={innerClassName} />}
+      {isChanged && (
+        <>
+          <FillArrowSvg
+            className={innerClassName}
+            transform={rankChange > 0 ? '' : 'rotate(180)'}
+          />
+          <p className={clsx(innerClassName, 'text-[11px] font-semibold')}>
+            {Math.abs(rankChange)}
+          </p>
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/components/pages/home/trending-posts/RankChange.tsx
+++ b/src/components/pages/home/trending-posts/RankChange.tsx
@@ -18,12 +18,6 @@ export const RankChange = ({
   const isSame = !isNew && rankChange === 0;
   const isChanged = !isNew && rankChange !== 0;
 
-  console.log({
-    isNew,
-    isSame,
-    isChanged,
-  });
-
   return (
     <div
       className={clsx(

--- a/src/components/pages/home/trending-posts/TopRanking.tsx
+++ b/src/components/pages/home/trending-posts/TopRanking.tsx
@@ -1,17 +1,18 @@
 'use client';
 
 import CrownLinearSvg from '@/components/svg-component/CrownLinearSvg';
-import FillArrowSvg from '@/components/svg-component/FillArrowSvg';
+import type { TrendWord } from '@/fetcher/types';
 import clsx from 'clsx';
 import { useEffect, useState } from 'react';
+import { RankChange } from './RankChange';
 
 const TopRankingItem = ({
+  trendWord,
   index,
-  item,
   isMount,
 }: {
+  trendWord: TrendWord;
   index: number;
-  item: number;
   isMount: boolean;
 }) => {
   const gradientStyles = [
@@ -19,6 +20,8 @@ const TopRankingItem = ({
     'bg-rank-gradient-two duration-1000 w-[316px] xs:w-[366px]',
     'bg-rank-gradient-three h-[67px] duration-[1300ms] w-[292px] xs:w-[342px]',
   ];
+
+  const { rank, rankChange, name, pronunciation, diacritic } = trendWord;
 
   return (
     <div
@@ -32,7 +35,7 @@ const TopRankingItem = ({
     >
       {/* 크라운, 순위 컨테이너 */}
       <div className="relative">
-        <CrownLinearSvg rank={String(index + 1)} />
+        <CrownLinearSvg rank={String(rank)} />
         <p
           className={clsx(
             'absolute text-[10px] top-3 font-bold left-[10.5px]',
@@ -57,7 +60,7 @@ const TopRankingItem = ({
             index === 2 && 'text-[#334EAF]',
           )}
         >
-          {item}
+          {name}
         </p>
 
         {/* 발음 및 발음 기호 */}
@@ -68,7 +71,7 @@ const TopRankingItem = ({
               index === 2 && 'text-[#5C6892]',
             )}
           >
-            {item}
+            {pronunciation}
           </p>
           <p
             className={clsx(
@@ -76,24 +79,24 @@ const TopRankingItem = ({
               index !== 2 ? 'text-white/50' : 'text-[#5C6892]/50',
             )}
           >
-            {item}
+            {diacritic}
           </p>
         </span>
       </div>
-      <div
-        className={clsx(
-          'mr-[22px] bg-white/20 rounded-xl w-[34px] h-[17px] px-[3px] flex items-center justify-center',
-          index !== 2 ? 'text-white' : 'text-[#495685]',
-        )}
-      >
-        <FillArrowSvg />
-        <p className="text-[11px] font-semibold">{item}</p>
-      </div>
+      <RankChange
+        className="bg-white/20 text-main-blue"
+        innerClassName={clsx(index !== 2 ? 'text-white' : 'text-[#495685]')}
+        rankChange={rankChange}
+      />
     </div>
   );
 };
 
-export default function TopRanking() {
+type Props = {
+  topRankingList: TrendWord[];
+};
+
+export default function TopRanking({ topRankingList }: Props) {
   const [isMount, setIsMount] = useState(false);
 
   useEffect(() => {
@@ -101,16 +104,14 @@ export default function TopRanking() {
     return () => clearTimeout(timer);
   }, []);
 
-  const dummyItems = [1, 2, 3];
-
   return (
     <div className="mt-[28px] w-full">
       <div className="-mx-[20px] min-h-[219px] overflow-x-hidden">
-        {dummyItems.map((item, index) => (
+        {topRankingList.map((trendWord, index) => (
           <TopRankingItem
-            key={index}
+            key={trendWord.id}
             index={index}
-            item={item}
+            trendWord={trendWord}
             isMount={isMount}
           />
         ))}

--- a/src/components/pages/home/trending-posts/index.tsx
+++ b/src/components/pages/home/trending-posts/index.tsx
@@ -1,19 +1,20 @@
 import TopRanking from './TopRanking';
 import TrendingDescription from './TrendingDescription';
 import GeneralRanking from './GeneralRanking';
-import ComingSoonAlert from './ComingSoonAlert';
+import { useGetTrendList } from '@/hooks/query/useGetTrendList';
 
 export default function TrendingPosts() {
-  return (
-    <div className="relative">
-      <ComingSoonAlert />
 
-      {/* FIXME: 트렌딩 단어 오픈 후에는 ComingSoonAlert, 최상위 div 및 아래 px-5 제거 후 Fragment만 남겨두기 */}
-      <div className=" px-5">
-        <TrendingDescription />
-        <TopRanking />
-        <GeneralRanking />
-      </div>
+  const { data: currentWeekTrendList } = useGetTrendList();
+
+  const topRankingList = currentWeekTrendList.slice(0, 3);
+  const generalRankingList = currentWeekTrendList.slice(3);
+
+  return (
+    <div className='px-5'>
+      <TrendingDescription />
+      <TopRanking topRankingList={topRankingList} />
+      <GeneralRanking generalRankingList={generalRankingList} />
     </div>
   );
 }

--- a/src/components/svg-component/FillArrowSvg.tsx
+++ b/src/components/svg-component/FillArrowSvg.tsx
@@ -1,4 +1,6 @@
-export default function FillArrowSvg() {
+import { ComponentProps } from 'react';
+
+export default function FillArrowSvg(props: ComponentProps<'svg'>) {
   return (
     <svg
       width="11"
@@ -6,6 +8,7 @@ export default function FillArrowSvg() {
       viewBox="0 0 11 11"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      {...props}
     >
       <path
         d="M5.09038 3.58517C5.28943 3.30081 5.71057 3.30081 5.90962 3.58517L8.44929 7.21327C8.68126 7.54466 8.44418 8 8.03967 8H2.96033C2.55582 8 2.31874 7.54466 2.55071 7.21327L5.09038 3.58517Z"

--- a/src/components/svg-component/HyphenSvg.tsx
+++ b/src/components/svg-component/HyphenSvg.tsx
@@ -1,0 +1,9 @@
+import { ComponentProps } from 'react';
+
+export default function HyphenSvg(props: ComponentProps<'svg'>) {
+  return (
+    <svg width="8" height="2" viewBox="0 0 8 2" fill="currentColor" {...props}>
+      <path d="M1 1H7" stroke="currentColor" stroke-linecap="round" />
+    </svg>
+  );
+}

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -5,6 +5,7 @@ const QUERY_KEYS = Object.freeze({
   LIKEDWORD_KEY: 'likedWord',
   AUTH_KEY: 'auth',
   USER_KEY: 'user',
+  TREND: 'trend'
 } as const);
 
 export default QUERY_KEYS;

--- a/src/fetcher/server.ts
+++ b/src/fetcher/server.ts
@@ -1,5 +1,5 @@
 import { serverFetch } from '@/fetcher/serverFetch.ts';
-import { DefaultRes, FetchRes, UserData } from '@/fetcher/types.ts';
+import { DefaultRes, FetchRes, TrendWordData, UserData } from '@/fetcher/types.ts';
 import { MainItemType, PaginationRes } from '@/types/main.ts';
 import { notFound } from 'next/navigation';
 
@@ -23,4 +23,15 @@ export const getAllPostsServer = async (currentPage: number) => {
 
 export const getUserInfoServer = async () => {
   return await serverFetch<FetchRes<DefaultRes<UserData>>>(`/user`);
+};
+
+export const getCurrentWeekTrendList = async () => {
+  try {
+    return await serverFetch<FetchRes<DefaultRes<TrendWordData>>>(
+      `/ranking/current`,
+    );
+  } catch (e) {
+    console.log('error', e);
+    notFound();
+  } 
 };

--- a/src/fetcher/types.ts
+++ b/src/fetcher/types.ts
@@ -135,3 +135,15 @@ export type AutoCompleteWordData = {
   name: string;
   diacritic: string;
 };
+
+export type TrendWord = {
+  rank: number;
+  rankChange?: number;
+  id: string;
+  name: string;
+  description: string;
+  diacritic: string;
+  pronunciation: string;
+};
+
+export type TrendWordData = TrendWord[];

--- a/src/hooks/query/useGetTrendList.ts
+++ b/src/hooks/query/useGetTrendList.ts
@@ -1,0 +1,11 @@
+import QUERY_KEYS from '@/constants/queryKey';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { getCurrentWeekTrendList } from '@/fetcher/server';
+
+export const useGetTrendList = () => {
+  return useSuspenseQuery({
+    queryKey: [QUERY_KEYS.TREND],
+    queryFn: () => getCurrentWeekTrendList(),
+    select: (response) => response.data.data
+  });
+};


### PR DESCRIPTION
## 📌 기능 설명
- [x] 랭킹 순위 컴포넌트 내 Props 를 적용하고, 서버에서 받은 데이터를 사용하도록 구조 변경
- [x] server fetcher 내에 트렌딩 단어 목록을 가져오는 API 추가

## 📌 구현 내용
- `TopRanking`, `GeneralRanking` 컴포넌트에 Props 를 정의하고, 서버에서 받은 단어 정보를 적용하도록 했습니다.
- `RankChange` 컴포넌트를 제작하고 이전 주차와 현재 주차 간의 변화를 보여주도록 설정했습니다.
- `useGetTrendingList` Query Hook 을 제작하고 이를 Page 컴포넌트에서 사용하도록 수정했습니다.

## 📌 구현 결과
![333](https://github.com/Devminjeong-eum/frontend/assets/74497253/3fc6455e-7c25-465e-aa53-ea3d2841dcbe)

## 📌 논의하고 싶은 점
- 현재 RankingChange 컴포넌트의 구조가 아무래도 급하게 개발되다 보니 구조가 상당히 좋지 못합니다.
- 혹시 더 좋은 의견이나 구조가 있다면 가감없이 알려주시면 감사하겠습니다.