### PR TITLE
fix: URL 공유 모달 뜰 때, 한번 더 클릭 시 없어지도록 변경

### DIFF
--- a/src/components/common/CopiedNotice.tsx
+++ b/src/components/common/CopiedNotice.tsx
@@ -5,20 +5,18 @@ interface Props {
   handleClose: () => void;
 }
 export function CopiedNotice({ isOpen, handleClose }: Props) {
-  if (isOpen) {
-    return (
-      <div
-        className="w-screen h-screen fixed left-0 top-0 flex justify-center items-center z-10"
-        onClick={handleClose}
-      >
-        <div className="w-full h-screen flex justify-center items-center max-w-[430px] bg-[#000000] opacity-70 mix-blend-multiply" />
-        <div className="absolute flex gap-1.5 py-4 px-[22px] rounded-[16px] bg-[#05050555]">
-          <CheckSvg />
-          <span className="font-semibold text-white">링크 복사 완료</span>
-        </div>
-      </div>
-    );
-  }
+  if (!isOpen) return null;
 
-  return null;
+  return (
+    <div
+      className="w-screen h-screen fixed left-0 top-0 flex justify-center items-center z-10"
+      onClick={handleClose}
+    >
+      <div className="w-full h-screen flex justify-center items-center max-w-[430px] bg-[#000000] opacity-70 mix-blend-multiply" />
+      <div className="absolute flex gap-1.5 py-4 px-[22px] rounded-[16px] bg-[#05050555]">
+        <CheckSvg />
+        <span className="font-semibold text-white">링크 복사 완료</span>
+      </div>
+    </div>
+  );
 }

--- a/src/components/common/CopiedNotice.tsx
+++ b/src/components/common/CopiedNotice.tsx
@@ -1,13 +1,24 @@
 import CheckSvg from '@/components/svg-component/CheckSvg.tsx';
 
-export function CopiedNotice() {
-  return (
-    <div className="w-screen h-screen fixed left-0 top-0 flex justify-center items-center z-10">
-      <div className="w-full h-screen flex justify-center items-center max-w-[430px] bg-[#000000] opacity-70 mix-blend-multiply" />
-      <div className="absolute flex gap-1.5 py-4 px-[22px] rounded-[16px] bg-[#05050555]">
-        <CheckSvg />
-        <span className="font-semibold text-white">링크 복사 완료</span>
+interface Props {
+  isOpen: boolean;
+  handleClose: () => void;
+}
+export function CopiedNotice({ isOpen, handleClose }: Props) {
+  if (isOpen) {
+    return (
+      <div
+        className="w-screen h-screen fixed left-0 top-0 flex justify-center items-center z-10"
+        onClick={handleClose}
+      >
+        <div className="w-full h-screen flex justify-center items-center max-w-[430px] bg-[#000000] opacity-70 mix-blend-multiply" />
+        <div className="absolute flex gap-1.5 py-4 px-[22px] rounded-[16px] bg-[#05050555]">
+          <CheckSvg />
+          <span className="font-semibold text-white">링크 복사 완료</span>
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
+
+  return null;
 }

--- a/src/components/common/ShareModal.tsx
+++ b/src/components/common/ShareModal.tsx
@@ -12,7 +12,7 @@ export default function ShareModal() {
   const { handleShare } = useLoadKakaoScript();
   const router = useRouter();
   const shareURL = window.location.href;
-  const { isCopied, onCopyClipboard } = useCopyClipboard({
+  const { isCopied, onCopyClipboard, onCloseCopyClipboard } = useCopyClipboard({
     url: shareURL,
   });
 
@@ -44,7 +44,7 @@ export default function ShareModal() {
           </div>
         </div>
       </div>
-      {isCopied && <CopiedNotice />}
+      <CopiedNotice isOpen={isCopied} handleClose={onCloseCopyClipboard} />
     </div>
   );
 }

--- a/src/components/pages/detail/URLShareButton.tsx
+++ b/src/components/pages/detail/URLShareButton.tsx
@@ -7,7 +7,7 @@ export default function URLShareButton() {
 
   return (
     <div>
-      <button onClick={() => onCopyClipboard()}>
+      <button onClick={onCopyClipboard}>
         <ExternalSvg />
       </button>
       {isCopied && <CopiedNotice />}

--- a/src/components/pages/detail/URLShareButton.tsx
+++ b/src/components/pages/detail/URLShareButton.tsx
@@ -3,14 +3,15 @@ import useCopyClipboard from '@/hooks/useCopyClipboard.ts';
 import { CopiedNotice } from '@/components/common/CopiedNotice.tsx';
 
 export default function URLShareButton() {
-  const { isCopied, onCopyClipboard } = useCopyClipboard();
+  const { isCopied, onCopyClipboard, onCloseCopyClipboard } =
+    useCopyClipboard();
 
   return (
     <div>
       <button onClick={onCopyClipboard}>
         <ExternalSvg />
       </button>
-      {isCopied && <CopiedNotice />}
+      {<CopiedNotice isOpen={isCopied} handleClose={onCloseCopyClipboard} />}
     </div>
   );
 }

--- a/src/hooks/useCopyClipboard.ts
+++ b/src/hooks/useCopyClipboard.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 async function copyURL(url?: string) {
   const targetUrl = url ? url : window.document.location.href;
@@ -28,10 +28,14 @@ export default function useCopyClipboard(props?: Props) {
     };
   }, [isCopied, props?.ms]);
 
-  const onCopyClipboard = async () => {
+  const onCopyClipboard = useCallback(async () => {
     await copyURL(props?.url);
     setIsCopied(true);
-  };
+  }, [props?.url]);
 
-  return { isCopied, onCopyClipboard };
+  const onCloseCopyClipboard = useCallback(() => {
+    setIsCopied(false);
+  }, []);
+
+  return { isCopied, setIsCopied, onCopyClipboard, onCloseCopyClipboard };
 }


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
- [x] 헤더 컴포넌트 구현 
-->
- [X] URL 공유 모달 뜰 때, 한번 더 클릭 시 없어지도록 변경

## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->
 URL 공유 안내 모달이 한번 더 클릭 시 없어지도록 변경했습니다.
상태의 props를 받는 형식으로 변경했습니다. 
<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->

## 📌 구현 결과
<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->
사파리에서 URL을 복사하지 않는 이슈가 있었는데, 갑자기 가능해져서, 확인할 수 없게 되었습니다. 지켜봐야 할 필요성이 있습니다!