### PR TITLE
[DEV-143] 단어 검색 및 상세 정보 열람 페이지에 URL Encoding 적용

### DIFF
--- a/src/app/word/search/page.tsx
+++ b/src/app/word/search/page.tsx
@@ -7,10 +7,11 @@ import { cookies } from 'next/headers';
 export async function generateMetadata(
   {
     searchParams,
-  }: { searchParams: { [key: string]: string | string[] | undefined } },
+  }: { searchParams: { keyword: string } },
   parent: ResolvingMetadata,
 ) {
   const parentMetadata = (await parent) || [];
+  const decodedKeyword = decodeURI(searchParams.keyword);
 
   const openGraph = parentMetadata?.openGraph ?? {};
   const twitter = parentMetadata?.twitter ?? {};
@@ -18,23 +19,23 @@ export async function generateMetadata(
   return {
     ...parentMetadata,
     title: {
-      absolute: `'${searchParams.keyword}'의 검색결과 | 데브말싸미`,
+      absolute: `'${decodedKeyword}'의 검색결과 | 데브말싸미`,
     },
-    description: `'${searchParams.keyword}'에 대한 검색 결과를 확인해보세요.`,
+    description: `'${decodedKeyword}'에 대한 검색 결과를 확인해보세요.`,
     robots: {
       index: false,
       follow: false,
     },
     openGraph: {
       ...openGraph,
-      title: { absolute: `'${searchParams.keyword}'의 검색결과 | 데브말싸미` },
-      description: `'${searchParams.keyword}'에 대한 검색 결과를 확인해보세요.`,
+      title: { absolute: `'${decodedKeyword}'의 검색결과 | 데브말싸미` },
+      description: `'${decodedKeyword}'에 대한 검색 결과를 확인해보세요.`,
       url: 'https://dev-malssami.site/search',
     },
     twitter: {
       ...twitter,
-      title: { absolute: `'${searchParams.keyword}'의 검색결과 | 데브말싸미` },
-      description: `'${searchParams.keyword}'에 대한 검색 결과를 확인해보세요.`,
+      title: { absolute: `'${decodedKeyword}'의 검색결과 | 데브말싸미` },
+      description: `'${decodedKeyword}'에 대한 검색 결과를 확인해보세요.`,
     },
   };
 }

--- a/src/app/words/[wordName]/page.tsx
+++ b/src/app/words/[wordName]/page.tsx
@@ -14,13 +14,14 @@ export async function generateMetadata(
   parent: ResolvingMetadata,
 ) {
   const parentMetadata = (await parent) || [];
+  const decodedWordName = decodeURIComponent(params.wordName);
 
   const openGraph = parentMetadata?.openGraph ?? {};
   const twitter = parentMetadata?.twitter ?? {};
 
   const {
     data: { name, pronunciation, wrongPronunciation },
-  } = await getWordDetail('NAME', params.wordName.toLowerCase());
+  } = await getWordDetail('NAME', decodedWordName.toLowerCase());
 
   return {
     ...parentMetadata,
@@ -71,7 +72,7 @@ export default async function WordsPage({
 }: {
   params: { wordName: string };
 }) {
-  const { wordName } = params;
+  const decodedWordName = decodeURIComponent(params.wordName);
   const {
     data: {
       id,
@@ -84,7 +85,7 @@ export default async function WordsPage({
       isLike,
       likeCount,
     },
-  } = await getWordDetail('NAME', wordName.toLowerCase());
+  } = await getWordDetail('NAME', decodedWordName.toLowerCase());
 
   /*
   NOTE: 한글 발음 표기 - 영어 발음 표기  1 : 1로 라고 생각함.

--- a/src/components/layout/SearchBar.tsx
+++ b/src/components/layout/SearchBar.tsx
@@ -3,14 +3,13 @@
 import MagnifierSvg from '@/components/svg-component/MagnifierSvg';
 import useScroll from '@/hooks/useScroll';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useState, type ChangeEvent } from 'react';
+import { useState, type ChangeEvent, useRef } from 'react';
 import clsx from 'clsx';
 import { getAutoCompleteWord } from '@/fetcher';
 import type { AutoCompleteWordData } from '@/fetcher/types';
 import AutoComplete from '../pages/search/AutoComplete';
 import { useOnClickOutside } from '@/hooks/useOnClickOutside';
 import { useDebounce } from '@/hooks/useDebounce';
-import { useRef } from 'react';
 import EngOnlyAlert from '../pages/search/EngOnlyAlert';
 import { getWordDetailPath } from '@/routes/path';
 
@@ -107,7 +106,7 @@ export default function SearchBar() {
   };
 
   const handleWordSearch = (searchKeyword: string) => {
-    router.push(`/word/search?keyword=${searchKeyword}`);
+    router.push(`/word/search?keyword=${encodeURIComponent(searchKeyword)}`);
     setSearchInput(searchKeyword);
     setIsDropdownOpen(false);
   };

--- a/src/routes/path.ts
+++ b/src/routes/path.ts
@@ -8,7 +8,7 @@ export const WORD_INQUIRY_FORM_URL = 'https://forms.gle/McGVzfsVT9SQkt1g8';
 export const OTHER_INQUIRY_FORM_URL =
   'https://docs.google.com/forms/d/e/1FAIpQLSd2XQqzR3dDb1aq_ipTmagcZr3f-uSwTqQsLpSB6u_vq9oxBA/viewform';
 
-export const getWordDetailPath = (wordName: string) => `/words/${wordName}`;
+export const getWordDetailPath = (wordName: string) => `/words/${encodeURIComponent(wordName)}`;
 export const getSearchPath = (wordName: string) => `/word/search/${wordName}`;
 export const getQuizResultPath = (quizId: string) => `/quiz/result/${quizId}`;
 export const getQuizResultSharePath = (quizId: string) =>


### PR DESCRIPTION
## 📌 기능 설명
- [x] 단어 검색 페이지에서 keyword 에 특수 문자가 들어갈 경우 URL Encoding 적용
- [x] 단어 상세 페이지에서 keyword 에 특수 문자가 들어갈 경우 URL Encoding 적용

## 📌 구현 내용
- `shadcn/ui` 처럼 특수 문자가 포함된 경우 `/` 기호를 라우팅 처리에 사용했던 오류를 수정했습니다.
- 단어 검색 및 상세 정보 열람 시 keyword 를 URL Encoding 처리하고, 받는 단에서 Decode 하도록 수정했습니다.

## 📌 구현 결과
1. 단어 검색 페이지
![888](https://github.com/Devminjeong-eum/frontend/assets/74497253/e7aff6e6-febc-4ed3-a654-716cc350dffe)

2. 단어 상세 정보 페이지
![999](https://github.com/Devminjeong-eum/frontend/assets/74497253/182e3c2c-3ae7-4779-831c-4ce103a54986)
