### PR TITLE
[DEV-156] 트렌딩 단어 페이지에서 순위 아이템 클릭시 바로 디테일 페이지로 이동되도록 수정

### DIFF
--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -22,7 +22,7 @@ const HomeClientPage = () => {
   );
 
   return (
-    <main className="py-5 rounded-[24px] bg-[#FBFCFE] -mt-[20px] z-50 flex flex-col gap-[8px]">
+    <main className="py-5 rounded-[24px] bg-[#FBFCFE] min-h-screen -mt-[20px] z-50 flex flex-col gap-[8px]">
       <div className="px-5">
         <HomeToggleZone handleToggle={handleToggle} isTrending={isTrending} />
       </div>

--- a/src/components/pages/home/trending-posts/GeneralRanking.tsx
+++ b/src/components/pages/home/trending-posts/GeneralRanking.tsx
@@ -1,17 +1,21 @@
 import { TrendWord } from '@/fetcher/types';
 import clsx from 'clsx';
 import { RankChange } from './RankChange';
+import { getWordDetailPath } from '@/routes/path';
+import { useRouter } from 'next/navigation';
 
 type Props = {
   generalRankingList: TrendWord[];
 };
 
 export default function GeneralRanking({ generalRankingList }: Props) {
+  const router = useRouter();
+
   return (
     <div className="w-full mt-[22px] border-[#F2F4F9] border-[1px] rounded-2xl py-[22px]">
       {generalRankingList.map((trendWord, index) => (
         <div
-          key={index}
+          key={trendWord.id}
           className={clsx(
             'h-[54px] border-[#ECEEF5] border-b-[1px] w-full flex items-center',
             index === 0 && '-mt-[6px]',
@@ -24,13 +28,18 @@ export default function GeneralRanking({ generalRankingList }: Props) {
           </p>
 
           {/* 영단어 컨테이너 */}
-          <span className="flex ml-[29px] gap-[6px] flex-1 items-end ">
-            <p className="text-[16px] text-main-black">{trendWord.name}</p>
-            <span className="text-[#F2F4F9]">|</span>
+          <button
+            className="flex ml-[29px] gap-[6px] flex-1 items-end group"
+            onClick={() => router.push(getWordDetailPath(trendWord.name))}
+          >
+            <p className="text-[16px] text-main-black group-hover:underline">
+              {trendWord.name}
+            </p>
+            <span className="text-[#F2F4F9] hover:no-underline">|</span>
             <p className="text-[#6F6F80] text-[14px]">
               {trendWord.pronunciation}
             </p>
-          </span>
+          </button>
 
           {/* 순위 등락 컨테이너  */}
           <RankChange

--- a/src/components/pages/home/trending-posts/GeneralRanking.tsx
+++ b/src/components/pages/home/trending-posts/GeneralRanking.tsx
@@ -10,12 +10,12 @@ type Props = {
 
 export default function GeneralRanking({ generalRankingList }: Props) {
   return (
-    <div className="w-full mt-[22px] border-[#F2F4F9] border-[1px] rounded-2xl py-[22px]">
+    <div className="w-full mt-[22px] border-[#F2F4F9] border-[1px] rounded-2xl py-[8px] ">
       {generalRankingList.map((trendWord, index) => (
         <div
           key={trendWord.id}
           className={clsx(
-            'h-[54px] border-[#ECEEF5] border-b-[1px] w-full flex items-center',
+            'h-[54px] border-[#ECEEF5] border-b-[1px] w-full flex items-center ',
             index === 0 && '-mt-[6px]',
             index === 6 && 'border-none',
           )}
@@ -28,13 +28,12 @@ export default function GeneralRanking({ generalRankingList }: Props) {
           {/* 영단어 컨테이너 */}
           <Link
             href={getWordDetailPath(trendWord.name)}
-            className="flex ml-[29px] gap-[6px] flex-1 items-end group"
+            className="flex ml-[29px] gap-[6px] flex-1 items-center group"
           >
-            <p className="text-[16px] text-main-black group-hover:underline">
+            <p className="text-[16px] leading-[17px] font-medium text-main-black group-hover:underline underline-offset-2">
               {trendWord.name}
             </p>
-            <span className="text-[#F2F4F9] hover:no-underline">|</span>
-            <p className="text-[#6F6F80] text-[14px]">
+            <p className="text-[#6F6F80] text-[14px] font-medium">
               {trendWord.pronunciation}
             </p>
           </Link>

--- a/src/components/pages/home/trending-posts/GeneralRanking.tsx
+++ b/src/components/pages/home/trending-posts/GeneralRanking.tsx
@@ -2,15 +2,13 @@ import { TrendWord } from '@/fetcher/types';
 import clsx from 'clsx';
 import { RankChange } from './RankChange';
 import { getWordDetailPath } from '@/routes/path';
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 
 type Props = {
   generalRankingList: TrendWord[];
 };
 
 export default function GeneralRanking({ generalRankingList }: Props) {
-  const router = useRouter();
-
   return (
     <div className="w-full mt-[22px] border-[#F2F4F9] border-[1px] rounded-2xl py-[22px]">
       {generalRankingList.map((trendWord, index) => (
@@ -28,9 +26,9 @@ export default function GeneralRanking({ generalRankingList }: Props) {
           </p>
 
           {/* 영단어 컨테이너 */}
-          <button
+          <Link
+            href={getWordDetailPath(trendWord.name)}
             className="flex ml-[29px] gap-[6px] flex-1 items-end group"
-            onClick={() => router.push(getWordDetailPath(trendWord.name))}
           >
             <p className="text-[16px] text-main-black group-hover:underline">
               {trendWord.name}
@@ -39,7 +37,7 @@ export default function GeneralRanking({ generalRankingList }: Props) {
             <p className="text-[#6F6F80] text-[14px]">
               {trendWord.pronunciation}
             </p>
-          </button>
+          </Link>
 
           {/* 순위 등락 컨테이너  */}
           <RankChange

--- a/src/components/pages/home/trending-posts/TopRanking.tsx
+++ b/src/components/pages/home/trending-posts/TopRanking.tsx
@@ -5,6 +5,8 @@ import type { TrendWord } from '@/fetcher/types';
 import clsx from 'clsx';
 import { useEffect, useState } from 'react';
 import { RankChange } from './RankChange';
+import { useRouter } from 'next/navigation';
+import { getWordDetailPath } from '@/routes/path';
 
 const TopRankingItem = ({
   trendWord,
@@ -15,19 +17,23 @@ const TopRankingItem = ({
   index: number;
   isMount: boolean;
 }) => {
+  const router = useRouter();
+  const { rank, rankChange, name, pronunciation, diacritic } = trendWord;
   const gradientStyles = [
     'bg-rank-gradient-one duration-700 w-[340px] xs:w-[390px]',
     'bg-rank-gradient-two duration-1000 w-[316px] xs:w-[366px]',
     'bg-rank-gradient-three h-[67px] duration-[1300ms] w-[292px] xs:w-[342px]',
   ];
 
-  const { rank, rankChange, name, pronunciation, diacritic } = trendWord;
+  const moveToDetailPage = () => {
+    router.push(getWordDetailPath(name));
+  };
 
   return (
     <div
-      key={`item_${index}`}
+      onClick={moveToDetailPage}
       className={clsx(
-        'h-[72px] rounded-r-[100px] flex items-center pl-[34px] transition-transform',
+        'h-[72px] rounded-r-[100px] flex items-center pl-[34px] transition-transform cursor-pointer',
         index !== 0 && 'mt-[4px]',
         gradientStyles[index],
         isMount ? 'translate-x-0' : '-translate-x-full',


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
- [x] 헤더 컴포넌트 구현 
-->

## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->
- 트렌딩 단어 페이지에서 순위 아이템을 클릭하게 될 경우 디테일 페이지로 이동되도록 수정하였습니다.

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->

## 📌 구현 결과
<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->

클릭 범위를 어디서부터 어떻게 설정해야할지 고민되어 우선 탑 랭킹(1,2,3)의 경우에는 어디를 클릭하더라도 디테일 페이지로 이동되도록 해두었고,  4~10위의 경우에는 전체 범위를 주니 개인적으로 어색한 점이 있는것 같아 우선 순위, 등락 ui를 제외한 텍스트 부분을 클릭할 경우 언더라인처리와 이동되도록 해두었습니다. 