### PR TITLE
[DEV-157] 모든 용어 보기 기본 노출 아이템 개수 수정

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -13,6 +13,7 @@ import {
   getCurrentWeekTrendList,
 } from '@/fetcher/server.ts';
 import HomeSkeleton from '@/components/pages/home/HomeSkeleton';
+import type { MainItemType, MainResponse } from '@/types/main';
 
 export default async function HomePage({
   searchParams: { page },
@@ -32,12 +33,17 @@ export default async function HomePage({
     }),
   ]);
 
+  const postsData: MainResponse<MainItemType> | undefined =
+    queryClient.getQueryData([QUERY_KEYS.HOME_KEY, Number(page)]);
+
   const isToken = cookies().has('accessToken');
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <Header isToken={isToken} />
-      <Suspense fallback={<HomeSkeleton />}>
+      <Suspense
+        fallback={<HomeSkeleton limit={Number(postsData?.data?.limit)} />}
+      >
         <HomeClientPage />
       </Suspense>
     </HydrationBoundary>

--- a/src/components/pages/home/HomeSkeleton.tsx
+++ b/src/components/pages/home/HomeSkeleton.tsx
@@ -3,7 +3,7 @@ import HeartSvg from '@/components/svg-component/HeartSvg';
 export default function HomeSkeleton() {
   return (
     <div className="flex flex-col gap-2 mt-4 px-5">
-      {Array.from({ length: 10 }, (_, idx) => (
+      {Array.from({ length: 16 }, (_, idx) => (
         <div
           key={idx}
           className="animate-pulse min-h-[98px] p-[18px] pb-[14px] w-full ring-1 bg-white ring-[#F2F4F9] rounded-2xl"

--- a/src/components/pages/home/HomeSkeleton.tsx
+++ b/src/components/pages/home/HomeSkeleton.tsx
@@ -1,9 +1,9 @@
 import HeartSvg from '@/components/svg-component/HeartSvg';
 
-export default function HomeSkeleton() {
+export default function HomeSkeleton({ limit }: { limit: number }) {
   return (
     <div className="flex flex-col gap-2 mt-4 px-5">
-      {Array.from({ length: 16 }, (_, idx) => (
+      {Array.from({ length: limit }, (_, idx) => (
         <div
           key={idx}
           className="animate-pulse min-h-[98px] p-[18px] pb-[14px] w-full ring-1 bg-white ring-[#F2F4F9] rounded-2xl"

--- a/src/components/pages/home/all-posts/index.tsx
+++ b/src/components/pages/home/all-posts/index.tsx
@@ -20,8 +20,7 @@ export default function AllPosts({
   const [isOpenModal, setIsOpenModal] = useState(false);
 
   return (
-    // FIXME: 트렌딩 단어 오픈 후에는 아래 px-5 제거하기
-    <div className="flex flex-col gap-[7px] mt-[20px] px-5">
+    <div className="flex flex-col gap-[7px] mt-[20px]">
       {data.data.map((item) => (
         <WordItem key={item.id} {...item} setIsOpenModal={setIsOpenModal} />
       ))}

--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -22,10 +22,8 @@ const HomeClientPage = () => {
   );
 
   return (
-    <main className="py-5 rounded-[24px] bg-[#FBFCFE] -mt-[20px] z-50 flex flex-col gap-[8px]">
-      <div className="px-5">
-        <HomeToggleZone handleToggle={handleToggle} isTrending={isTrending} />
-      </div>
+    <main className="py-5 rounded-[24px] bg-[#FBFCFE] -mt-[20px] z-50 flex flex-col gap-[8px] px-5">
+      <HomeToggleZone handleToggle={handleToggle} isTrending={isTrending} />
 
       {isTrending === 'trend' ? (
         <TrendingPosts />

--- a/src/components/pages/home/trending-posts/index.tsx
+++ b/src/components/pages/home/trending-posts/index.tsx
@@ -11,10 +11,10 @@ export default function TrendingPosts() {
   const generalRankingList = currentWeekTrendList.slice(3);
 
   return (
-    <div className='px-5'>
+    <>
       <TrendingDescription />
       <TopRanking topRankingList={topRankingList} />
       <GeneralRanking generalRankingList={generalRankingList} />
-    </div>
+    </>
   );
 }

--- a/src/components/pages/search/index.tsx
+++ b/src/components/pages/search/index.tsx
@@ -21,7 +21,6 @@ export default function Search({ word }: Props) {
   } = useGetSearchWord(word.toLowerCase());
 
   return (
-    // FIXME: 트렌딩 단어 오픈 후에는 아래 px-5 제거하기
     <div className="flex flex-col gap-[7px] mt-[17px] px-5">
       {!totalCount && <NotFoundWord />}
       {data.map((item) => (

--- a/src/fetcher/index.ts
+++ b/src/fetcher/index.ts
@@ -79,7 +79,7 @@ export const getAllPostsClient = async (currentPage: number) => {
     >(`/word/list`, {
       params: {
         page: currentPage,
-        limit: 10,
+        limit: 16,
       },
     });
 

--- a/src/fetcher/server.ts
+++ b/src/fetcher/server.ts
@@ -15,7 +15,7 @@ export const getAllPostsServer = async (currentPage: number) => {
     >(`/word/list`, {
       params: {
         page: currentPage,
-        limit: 10,
+        limit: 16,
       },
     });
 

--- a/src/hooks/useLoadKakaoScript.ts
+++ b/src/hooks/useLoadKakaoScript.ts
@@ -24,7 +24,6 @@ export default function useLoadKakaoScript() {
   const title = `${userName}님의 개발 용어 점수는?`;
   const desc = `${userName}님의 개발 용어 점수는 몇 점일까요? 클릭해서 확인해보고, 함께 도전해보세요!`;
 
-  // FIXME: 나중에 엔드포인트가 quiz/quizID와 같이 바뀔텐데 아직 정해진게 없는것 같아서 추후 수정 예정
   const urlEndPoint = window.location.href.split('/').slice(3).join('/');
   const path = urlEndPoint;
 

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -8,6 +8,17 @@ export type MainItemType = {
   likeCount?: number;
 };
 
+export type MainResponse<TData> = {
+  status: number;
+  data: {
+    data: TData[];
+    page: number;
+    limit: number;
+    isLast: boolean;
+    totalCount: number;
+  };
+};
+
 export type PaginationRes<TData> = {
   data: TData;
   page: number;


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
- [x] 헤더 컴포넌트 구현 
-->

## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->
- 기본 노출 아이템 개수를 기존 10개에서 16개로 수정하였습니다.

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->

## 📌 구현 결과
<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->