### PR TITLE
fix: quiz refetch 설정, staleTIme, gcTime 설정 및 퀴즈 데이터 revalidate 처리

### DIFF
--- a/src/components/pages/quiz/index.tsx
+++ b/src/components/pages/quiz/index.tsx
@@ -7,10 +7,13 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSetAtom } from 'jotai/react';
 import { guestQuizAtom } from '@/store';
+import QUERY_KEYS from '@/constants/queryKey.ts';
+import { useQueryClient } from '@tanstack/react-query';
 
 export default function Quiz() {
   const [isShow, setIsShow] = useState(false);
   const router = useRouter();
+  const queryClient = useQueryClient();
   const setQuizAtom = useSetAtom(guestQuizAtom);
 
   const handleClickPlayButton = () => {
@@ -20,6 +23,8 @@ export default function Quiz() {
         incorrectWordData: [],
       };
     });
+
+    queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.QUIZ_KEY] });
     setIsShow(true);
   };
 

--- a/src/hooks/query/useGetQuizData.ts
+++ b/src/hooks/query/useGetQuizData.ts
@@ -6,5 +6,9 @@ export const useGetQuizData = () => {
   return useSuspenseQuery({
     queryKey: [QUERY_KEYS.QUIZ_KEY],
     queryFn: () => getQuizData(),
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
   });
 };


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
- [x] 헤더 컴포넌트 구현 
-->
- [x]퀴즈가 일정 시간 후 다시 불러와지는 문제 해결
-[X] 시간 내 퀴즈를 다시 요청하면 같은 퀴즈가 불러와지는 문제 해결
## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->

퀴즈 데이터에 대해서 캐싱 처리 전략을 수정했습니다. 
일정 시간이 지나도 퀴즈 페이지로 다시 돌아오면 퀴즈 데이터가 변경되지 않도록 staleTime과 gcTime을 Infinity로 수정하고, refetch를 false로  만들었습니다. 
또한 새로운 퀴즈에 진입할 때 데이터를 invalidate해서 새 퀴즈를 받을 수 있도록 만들었습니다. 

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->

## 📌 구현 결과
<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

기존 퀴즈는 6분이 지나서 다시 돌아오면 새로운 데이터를 받아왔는데, 해당 브랜치에서는 기존 데이터가 남아있습니다. 
또한 퀴즈를 시도할 때 마다 새로운 퀴즈가 불러와집니다. 

## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->