### PR TITLE
feat: 디테일 페이지 QA 반영, 안내문구 삽입

### DIFF
--- a/src/app/words/[wordName]/page.tsx
+++ b/src/app/words/[wordName]/page.tsx
@@ -7,6 +7,8 @@ import { serverFetch } from '@/fetcher/serverFetch.ts';
 import { notFound } from 'next/navigation';
 import PronunciationDetail from '@/components/pages/detail/PronunciationDetail.tsx';
 import { ResolvingMetadata } from 'next';
+import { DetailKoreanAlertIconSvg } from '@/components/svg-component/DetailKoreanAlertIconSvg.tsx';
+import React from 'react';
 
 // eslint-disable-next-line react-refresh/only-export-components
 export async function generateMetadata(
@@ -114,6 +116,10 @@ export default async function WordsPage({
               initialLikeCount={likeCount}
               wordId={id}
             />
+          </div>
+          <div className="text-[#F4F5FF] text-xs flex gap-[5px] pb-2.5">
+            <DetailKoreanAlertIconSvg />
+            한글 표기가 실제 발음과 차이가 있을 수 있습니다.
           </div>
           <PronunciationDetail
             pronunciation={pronunciation}

--- a/src/components/pages/detail/PronunciationDetail.tsx
+++ b/src/components/pages/detail/PronunciationDetail.tsx
@@ -23,9 +23,9 @@ const PronunciationDetail = ({
   const correctWordLen = Math.min(pronunciation.length, diacritic.length);
 
   return (
-    <div className="relative pb-4">
+    <div className="relative">
       <div
-        className={`flex flex-col gap-2 transition-all overflow-hidden ${clsx(isShowDetail ? 'max-h-[100vh]' : 'max-h-[0px]')}`}
+        className={`flex flex-col gap-2 transition-all overflow-hidden ${clsx(isShowDetail ? 'max-h-[100vh] pb-4' : 'max-h-[0px]')}`}
       >
         <div className="px-3.5 rounded-[14px] bg-[#D9E6FF] pt-3.5 pb-3">
           <span className="flex gap-1 items-center font-medium text-main-blue text-sm">
@@ -67,6 +67,7 @@ const PronunciationDetail = ({
           <DetailPronunciationShowArrowSvg />
         )}
       </div>
+      {/*{용어 발음 자세히 보기 버튼이 absolute이기 때문에 맞춰 58px 공간 확보}*/}
       <div className="h-[58px]" />
     </div>
   );

--- a/src/components/pages/detail/PronunciationDetail.tsx
+++ b/src/components/pages/detail/PronunciationDetail.tsx
@@ -6,6 +6,7 @@ import DetailPronunciationCorrectSvg from '@/components/svg-component/DetailPron
 import DetailPronunciationWrongSvg from '@/components/svg-component/DetailPronunciationWrongSvg.tsx';
 import DetailPronunciationShowArrowSvg from '@/components/svg-component/DetailPronunciationShowArrowSvg.tsx';
 import DetailPronunciationCloseArrowSvg from '@/components/svg-component/DetailPronunciationCloseArrowSvg.tsx';
+import { DetailKoreanAlertIconSvg } from '@/components/svg-component/DetailKoreanAlertIconSvg.tsx';
 
 interface Props {
   pronunciation: string[];
@@ -54,6 +55,10 @@ const PronunciationDetail = ({
               </span>
             ))}
           </div>
+        </div>
+        <div className="pl-4 text-[#F4F5FF] text-xs flex gap-[5px]">
+          <DetailKoreanAlertIconSvg />
+          한글 표기가 실제 발음과 차이가 있을 수 있습니다.
         </div>
       </div>
       <div

--- a/src/components/pages/detail/PronunciationDetail.tsx
+++ b/src/components/pages/detail/PronunciationDetail.tsx
@@ -6,7 +6,6 @@ import DetailPronunciationCorrectSvg from '@/components/svg-component/DetailPron
 import DetailPronunciationWrongSvg from '@/components/svg-component/DetailPronunciationWrongSvg.tsx';
 import DetailPronunciationShowArrowSvg from '@/components/svg-component/DetailPronunciationShowArrowSvg.tsx';
 import DetailPronunciationCloseArrowSvg from '@/components/svg-component/DetailPronunciationCloseArrowSvg.tsx';
-import { DetailKoreanAlertIconSvg } from '@/components/svg-component/DetailKoreanAlertIconSvg.tsx';
 
 interface Props {
   pronunciation: string[];
@@ -55,10 +54,6 @@ const PronunciationDetail = ({
               </span>
             ))}
           </div>
-        </div>
-        <div className="pl-4 text-[#F4F5FF] text-xs flex gap-[5px]">
-          <DetailKoreanAlertIconSvg />
-          한글 표기가 실제 발음과 차이가 있을 수 있습니다.
         </div>
       </div>
       <div

--- a/src/components/svg-component/DetailKoreanAlertIconSvg.tsx
+++ b/src/components/svg-component/DetailKoreanAlertIconSvg.tsx
@@ -1,0 +1,28 @@
+export function DetailKoreanAlertIconSvg() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="8" cy="8" r="8" fill="#5256D6" />
+      <circle
+        cx="8"
+        cy="8"
+        r="7.6"
+        stroke="white"
+        strokeOpacity="0.2"
+        strokeWidth="0.8"
+      />
+      <path
+        d="M8 4.5L8 8"
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <circle cx="8" cy="11.5" r="1" fill="white" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
-->

- [x] 디테일 페이지 QA반영(간격 조정)
- [X] 한글 표기 부정확 안내 문구 넣기

## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->

## 📌 구현 결과
<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->
<img width="451" alt="Screenshot 2024-07-03 at 12 55 08 PM" src="https://github.com/Devminjeong-eum/frontend/assets/75849590/35c1463c-5098-460c-91e0-5bc8645247d4">

## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->