### PR TITLE
[DEV-162] 단어장 페이지 QA 사항 반영

### DIFF
--- a/src/components/pages/wordbook/QuizBanner.tsx
+++ b/src/components/pages/wordbook/QuizBanner.tsx
@@ -7,11 +7,11 @@ export default function QuizBanner() {
       href={QUIZ_PATH}
       className="w-10/12 h-24 rounded-2xl bg-[#242C4B] flex gap-6 items-center justify-center"
     >
-      <div className="flex flex-col gap-2">
-        <span className="text-white opacity-70 font-medium text-sm">
+      <div className="flex flex-col gap-2 h-full">
+        <span className="text-white opacity-70 font-medium text-sm flex items-end h-full">
           퀴즈 풀고 내 점수 알아보자!
         </span>
-        <span className="text-white font-semibold text-lg">
+        <span className="text-white font-semibold text-lg flex items-start h-full">
           나의 개발 용어 발음 실력은?
         </span>
       </div>

--- a/src/components/pages/wordbook/index.tsx
+++ b/src/components/pages/wordbook/index.tsx
@@ -36,7 +36,7 @@ export default function Wordbook() {
           <div className="flex">
             <div className="w-[calc(46%+30px)] h-9 overflow-hidden rounded-tl-xl relative top-px">
               <div className="bg-[#FBFCFE] [transform:rotateY(180deg)_skew(-30deg)_translate(30px,0px)] h-full rounded-tl-md flex justify-center items-center">
-                <div className="[transform:rotateY(180deg)_skew(-30deg)_translate(-40px,0px)] pl-2.5 text-[#313140] font-medium text-[15px] leading-[18px] tracking-[-0.02em] opacity-90">
+                <div className="[transform:rotateY(180deg)_skew(-30deg)_translate(-40px,0px)] pl-2.5 pt-0.5 text-[#313140] font-medium text-[15px] leading-[18px] tracking-[-0.02em] opacity-90">
                   총 {totalCount}개
                 </div>
               </div>

--- a/src/components/pages/wordbook/index.tsx
+++ b/src/components/pages/wordbook/index.tsx
@@ -27,12 +27,12 @@ export default function Wordbook() {
   const { data: wordData, totalCount } = data.data.data;
 
   return (
-    <div>
+    <div className="bg-[#FBFCFE]">
       <div className="bg-wordbook-gradient h-32">
         <WordbookHeader />
       </div>
-      <div className="flex flex-col justify-between">
-        <div className="relative bottom-16 flex flex-col">
+      <div className="flex flex-col justify-between mt-[-4rem]">
+        <div className="flex flex-col">
           <div className="flex">
             <div className="w-[calc(46%+30px)] h-9 overflow-hidden rounded-tl-xl relative top-px">
               <div className="bg-[#FBFCFE] [transform:rotateY(180deg)_skew(-30deg)_translate(30px,0px)] h-full rounded-tl-md flex justify-center items-center">
@@ -47,7 +47,7 @@ export default function Wordbook() {
             />
           </div>
           {totalCount === 0 ? (
-            <div className="bg-[#FBFCFE] h-[calc(100vh-23rem)] flex flex-col justify-center items-center gap-2.5">
+            <div className="bg-[#FBFCFE] flex flex-col items-center gap-2.5 pt-[8.438rem] pb-[8.125rem]">
               <NoWordSvg />
               <span className="text-[#A8AEBC] font-medium text-center tracking-[-0.02em]">
                 좋아요를 누른 단어가 없어요.
@@ -72,7 +72,7 @@ export default function Wordbook() {
             </div>
           )}
         </div>
-        <div className="flex flex-col items-center gap-8 relative top-[-2rem]">
+        <div className="flex flex-col items-center gap-5 bg-[#FBFCFE] pb-7">
           {totalCount === 0 ? (
             <Link
               href={WORD_LIST_PATH}
@@ -81,13 +81,15 @@ export default function Wordbook() {
               <p className="text-[#383697] font-semibold">단어 검색하러 가기</p>
             </Link>
           ) : (
-            <Pagination
-              viewPaginationNums={4}
-              total={totalCount || 0}
-              limit={10}
-              setCurrent={setCurrentPage}
-              current={currentPage}
-            />
+            <div className="flex items-center justify-center w-10/12 h-14">
+              <Pagination
+                viewPaginationNums={4}
+                total={totalCount || 0}
+                limit={10}
+                setCurrent={setCurrentPage}
+                current={currentPage}
+              />
+            </div>
           )}
           <QuizBanner />
         </div>


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
- [x] 헤더 컴포넌트 구현 
-->

단어장 페이지 QA 사항 반영

## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->

- "총 용어 개수" 2px 내려가도록 `padding-bottom` 추가
- 퀴즈 배너 내부의 텍스트 정렬 추가
- 퀴즈 배너와 검색 버튼 간의 간격 수정
- NoWordSvg의 상하 `padding` 추가

## 📌 구현 결과
<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

![image](https://github.com/Devminjeong-eum/frontend/assets/55550034/ba6f58a1-467b-40ad-8757-a264eaae40e4)
![image](https://github.com/Devminjeong-eum/frontend/assets/55550034/e12231fa-57fd-4c71-bf87-8507cad7cbee)


## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->