### PR TITLE
[DEV-134] 복사완료화면이 오른쪽으로 밀리지 않도록 수정

### DIFF
--- a/src/components/common/CopiedNotice.tsx
+++ b/src/components/common/CopiedNotice.tsx
@@ -1,38 +1,16 @@
-'use client';
-
 import CheckSvg from '@/components/svg-component/CheckSvg.tsx';
-import { useEffect, useState } from 'react';
 
 interface Props {
   isOpen: boolean;
   handleClose: () => void;
 }
 
-const getScrollbarWidth = () => {
-  return window.innerWidth - document.documentElement.clientWidth;
-};
-
 export function CopiedNotice({ isOpen, handleClose }: Props) {
-  const [scrollbarWidth, setScrollbarWidth] = useState(0);
-  const [isReady, setIsReady] = useState(false);
-
-  useEffect(() => {
-    if (isOpen) {
-      const width = getScrollbarWidth();
-      setScrollbarWidth(width);
-      setIsReady(true);
-    } else {
-      setIsReady(false);
-      setScrollbarWidth(0);
-    }
-  }, [isOpen]);
-
-  if (!isOpen || !isReady) return null;
+  if (!isOpen) return null;
 
   return (
     <div
-      className="w-screen h-screen fixed left-0 top-0 flex justify-center items-center z-10"
-      style={{ paddingRight: `${scrollbarWidth}px` }}
+      className="w-full h-screen fixed top-0 left-0 flex justify-center items-center z-10"
       onClick={handleClose}
     >
       <div className="w-full h-screen flex justify-center items-center max-w-[430px] bg-[#000000] opacity-70 mix-blend-multiply" />

--- a/src/components/common/CopiedNotice.tsx
+++ b/src/components/common/CopiedNotice.tsx
@@ -1,15 +1,34 @@
+'use client';
+
 import CheckSvg from '@/components/svg-component/CheckSvg.tsx';
+import { useEffect, useState } from 'react';
 
 interface Props {
   isOpen: boolean;
   handleClose: () => void;
 }
+
+const getScrollbarWidth = () => {
+  return window.innerWidth - document.documentElement.clientWidth;
+};
+
 export function CopiedNotice({ isOpen, handleClose }: Props) {
+  const [scrollbarWidth, setScrollbarWidth] = useState(0);
+
+  useEffect(() => {
+    if (isOpen) {
+      setScrollbarWidth(getScrollbarWidth());
+    } else {
+      setScrollbarWidth(0);
+    }
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   return (
     <div
       className="w-screen h-screen fixed left-0 top-0 flex justify-center items-center z-10"
+      style={{ paddingRight: `${scrollbarWidth}px` }}
       onClick={handleClose}
     >
       <div className="w-full h-screen flex justify-center items-center max-w-[430px] bg-[#000000] opacity-70 mix-blend-multiply" />

--- a/src/components/common/CopiedNotice.tsx
+++ b/src/components/common/CopiedNotice.tsx
@@ -14,16 +14,20 @@ const getScrollbarWidth = () => {
 
 export function CopiedNotice({ isOpen, handleClose }: Props) {
   const [scrollbarWidth, setScrollbarWidth] = useState(0);
+  const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
-      setScrollbarWidth(getScrollbarWidth());
+      const width = getScrollbarWidth();
+      setScrollbarWidth(width);
+      setIsReady(true);
     } else {
+      setIsReady(false);
       setScrollbarWidth(0);
     }
   }, [isOpen]);
 
-  if (!isOpen) return null;
+  if (!isOpen || !isReady) return null;
 
   return (
     <div


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
- [x] 헤더 컴포넌트 구현 
-->

단어 디테일 페이지에서 공유하기 버튼 클릭 시 복사완료화면이 오른쪽으로 밀리지 않도록 수정

## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->

복사완료 알림의 상위 div는 `width: 100vh position:fixed; top:0; left:0;`로 위치와 width가 지정되어 있었습니다.
vw는 `width`는 세로스크롤바의 너비를 포함하기 때문에, 스크롤바를 포함한 `width`를 기준으로 모달의 위치가 지정되어서 모달이 오른쪽으로 치우쳤습니다. %로 지정하면 세로스크롤바의 너비를 제외한 너비로 가지기 떄문에 `width:100%`로 수정하여 오른쪽으로 화면이 이동하지 않도록 했습니다!

## 📌 구현 결과
<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

https://github.com/Devminjeong-eum/frontend/assets/55550034/5600251e-ccbc-4348-a915-c931243b0f7b


## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->